### PR TITLE
Change location of rtmpdump

### DIFF
--- a/tools/boxeebox/libs/CMakeLists.txt
+++ b/tools/boxeebox/libs/CMakeLists.txt
@@ -355,7 +355,7 @@ ExternalProject_Add(
 
 ExternalProject_Add(
 	rtmpdump
-	GIT_REPOSITORY    git://git.ffmpeg.org/rtmpdump
+	URL                   http://rtmpdump.mplayerhq.hu/download/rtmpdump-2.3.tgz
 	CONFIGURE_COMMAND ""
         BUILD_COMMAND     make DESTDIR=${SYSROOT} LIBS_posix=-L${TARGET_DIR}/lib XLIBS=-ldl INC=-I${TARGET_DIR}/include CROSS_COMPILE=${TARGET}-
         INSTALL_COMMAND   make install DESTDIR=${SYSROOT}


### PR DESCRIPTION
[ 86%] Performing download step (git clone) for 'rtmpdump'
Cloning into 'rtmpdump'...
fatal: https://git.ffmpeg.org/rtmpdump/info/refs?service=git-upload-pack not found: did you run git update-server-info on the server?
CMake Error at /home/django/Programs/boxeebox-xbmc/tools/boxeebox/build/libs-prefix/src/libs-build/rtmpdump-prefix/tmp/rtmpdump-gitclone.cmake:30 (message):
  Failed to clone repository: 'git://git.ffmpeg.org/rtmpdump'

make[5]: **\* [rtmpdump-prefix/src/rtmpdump-stamp/rtmpdump-download] Error 1
make[4]: **\* [CMakeFiles/rtmpdump.dir/all] Error 2
make[3]: **\* [all] Error 2
make[2]: **\* [libs-prefix/src/libs-stamp/libs-build] Error 2
make[1]: **\* [CMakeFiles/libs.dir/all] Error 2
make: **\* [all] Error 2
