### PR TITLE
Build environment changes + settings file added

### DIFF
--- a/system/settings/boxeebox.xml
+++ b/system/settings/boxeebox.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<settings>
+  <section id="system">
+    <category id="videoscreen">
+      <group id="1">
+        <setting id="videoscreen.blankdisplays">
+          <default>true</default>
+          <visible>false</visible>
+        </setting>
+      </group>
+      <group id="3">
+        <setting id="videoscreen.vsync">
+          <default>2</default> <!-- VSYNC_ALWAYS -->
+          <visible>false</visible>
+        </setting>
+      </group>
+    </category>
+  </section>
+</settings>

--- a/tools/boxeebox/CMakeLists.txt
+++ b/tools/boxeebox/CMakeLists.txt
@@ -114,7 +114,7 @@ set(libs
 	libturbojpeg.so.0
 	libsmbclient.so.0
         libnfs.so.1
-        librtmp.so.0
+        librtmp.so.1
         libdbus-1.so
 	libtdb.so.1
 	libtalloc.so.2

--- a/tools/boxeebox/libs/CMakeLists.txt
+++ b/tools/boxeebox/libs/CMakeLists.txt
@@ -333,8 +333,8 @@ ExternalProject_Add(
 
 ExternalProject_Add(
 	samba
-	URL 				http://ftp.samba.org/pub/samba/samba-3.6.19.tar.gz
-	URL_MD5 			afe9c7c590f3093555cd6e870d2532e1
+	URL 				http://ftp.samba.org/pub/samba/samba-3.6.20.tar.gz
+	URL_MD5 			3f1b60c681845ce6828a1abe5aacf671
 	CONFIGURE_COMMAND	CC=${TARGET}-gcc CFLAGS=-I${SYSROOT}/usr/local/include LDFLAGS=-L${SYSROOT}/usr/local/lib ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/source3 ./configure --prefix=${TARGET_DIR} --host=${TARGET} samba_cv_CC_NEGATIVE_ENUM_VALUES=yes libreplace_cv_HAVE_GETADDRINFO=no ac_cv_file__proc_sys_kernel_core_pattern=yes  samba_cv_HAVE_STAT_ST_FLAGS=no samba_cv_DARWIN_INITGROUPS=no --without-ldap --without-krb5 --without-ads --disable-cups --enable-swat=no --with-winbind=no
 	BUILD_COMMAND 		${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/source3 make ${PARALLEL} libsmbclient libtalloc libtevent libtdb
 	INSTALL_COMMAND 	${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/source3 make ${PARALLEL} installlibsmbclient installlibtalloc installlibtevent installlibtdb

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -609,7 +609,12 @@ bool CSettings::InitializeDefinitions()
 #endif
 #endif
 #endif
-
+  
+#if defined(TARGET_BOXEE)
+  if (CFile::Exists(SETTINGS_XML_FOLDER "boxeebox.xml") && !Initialize(SETTINGS_XML_FOLDER "boxeebox.xml"))
+    CLog::Log(LOGFATAL, "Unable to load boxeebox-specific settings definitions");
+#endif
+  
   // load any custom visibility and default values before loading the special
   // appliance.xml so that appliances are able to overwrite even those values
   InitializeVisibility();


### PR DESCRIPTION
Added a Boxee Box specific xml file for Settings config.
    *Vertical sync (always enabled)
    *Blank other displays (on)

Replaced samba version 3.6.19->3.6.20, old one have been remove from homepage.

Library for RTMP have changed name from librtmp.so.0 to librtmp.so.1 so changed build scripts accordingly.
