### PR TITLE
Build changes cross compile

### DIFF
--- a/tools/boxeebox/CMakeLists.txt
+++ b/tools/boxeebox/CMakeLists.txt
@@ -66,7 +66,7 @@ file(WRITE ${CMAKE_BINARY_DIR}/kodi_configure_helper.sh
 "
 #!/bin/sh
 PF=`${SYSROOT}/usr/bin/${TARGET}-pkg-config --libs python`
-export LDFLAGS=\"-L${local}/lib -lgcc -lm -ltinyxml -lgdl -lismd_core -lismd_viddec -lismd_vidpproc -lismd_audio -lismd_vidrend -lismd_demux -lismd_bufmon -losal -lplatform_config -Wl,-rpath=${SYSROOT}/usr/local/lib -Wl,-rpath=${SYSROOT}/lib -Wl,-rpath=${SYSROOT}/usr/lib\"
+export LDFLAGS=\"-L${local}/lib -lgcc -lm -ltinyxml -lgdl -liconv -lismd_core -lismd_viddec -lismd_vidpproc -lismd_audio -lismd_vidrend -lismd_demux -lismd_bufmon -losal -lplatform_config -Wl,-rpath=${SYSROOT}/usr/local/lib -Wl,-rpath=${SYSROOT}/lib -Wl,-rpath=${SYSROOT}/usr/lib\"
 export CFLAGS=\"-DTARGET_BOXEE=1 -DTIXML_USE_STL -mmmx -msse -msse2 -msse3 -I${local}/include -DHAS_INTEL_SMD -march=i686 -m32\"
 export CXXFLAGS=\"$CFLAGS\"
 export FREETYPE2_CFLAGS=\"-I${local}/include/freetype2\"
@@ -75,7 +75,8 @@ export PYTHON_NOVERSIONCHECK=\"y\"
 export PYTHON=\"${local}/bin/python\"
 export PYTHON_CPPFLAGS=\"-I${local}/include/python2.7\"
 export PYTHON_LDFLAGS=\"\$PF -ldl -lpthread -lutil\"
-${CMAKE_COMMAND} -E chdir ${CMAKE_SOURCE_DIR}/../../ ./configure --prefix=${local} --host=${TARGET} --build=i686-linux --with-ffmpeg --disable-gl --disable-pulse --disable-sdl ${MYSQL_CONF_PARAM} --disable-x11 --with-platform=linux32 --enable-gles --disable-joystick --enable-debug --enable-texturepacker --enable-nfs --enable-rtmp --enable-libcec=no --enable-libusb --with-lirc-device=/var/run/lirc/lircd --disable-sdl --enable-airplay
+export MYSQL_CONFIG=\"${local}/bin/mysql_config\"
+${CMAKE_COMMAND} -E chdir ${CMAKE_SOURCE_DIR}/../../ ./configure --prefix=${local} --host=${TARGET} --build=i686-linux --with-ffmpeg=shared --disable-gl --disable-pulse --disable-sdl ${MYSQL_CONF_PARAM} --disable-x11 --with-platform=linux32 --enable-gles --disable-joystick --enable-debug --enable-texturepacker --enable-nfs --enable-rtmp --enable-libcec=no --enable-libusb --with-lirc-device=/var/run/lirc/lircd --disable-sdl --enable-airplay --enable-debug=no
 "
 )
 execute_process(COMMAND chmod +x ${CMAKE_BINARY_DIR}/kodi_configure_helper.sh)
@@ -103,7 +104,7 @@ set(libs
 	airport.key
 	libafpclient.so.0
 	libao.so
-	libass.so.5
+	libass.so.4
 	libavahi-client.so.3
 	libavahi-common.so.3
 	libavahi-core.so.7
@@ -113,7 +114,6 @@ set(libs
 	libcrypto.so.1.0.0
 	libcurl.so.4
 	libdbus-1.so
-	libenca.so.0
 	libexpat.so
 	libffi.so.6
 	libFLAC.so
@@ -129,7 +129,6 @@ set(libs
 	libmpeg2.so.0
 	libnfs.so.4
 	libogg.so
-	libpcre.so.1
 	libplist.so.3
 	libpng15.so.15
 	libpython2.7.so.1.0
@@ -139,7 +138,6 @@ set(libs
 	libsmbclient.so.0
 	libssh.so.4
 	libssl.so.1.0.0
-	libtag.so.1
 	libtalloc.so.2
 	libtdb.so.1
 	libtevent.so.0
@@ -150,6 +148,7 @@ set(libs
 	libxml2.so
 	libxslt.so
 	libyajl.so.2
+	libiconv.so.2
 )
 
 foreach(lib ${libs})
@@ -270,7 +269,7 @@ add_custom_target(
 pvr
 cd ${CMAKE_SOURCE_DIR}
 COMMAND rm -rf ${CMAKE_SOURCE_DIR}/../../pvr-addons
-COMMAND git clone https://github.com/opdenkamp/xbmc-pvr-addons.git
+COMMAND git clone https://github.com/opdenkamp/xbmc-pvr-addons.git -b helix
 COMMAND  ${CMAKE_COMMAND} -E copy  ${CMAKE_SOURCE_DIR}/pvr-addons.patch ${CMAKE_SOURCE_DIR}/build/xbmc-pvr-addons
 COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/build/xbmc-pvr-addons/pvr-addons.patch
 COMMAND mv  ${CMAKE_SOURCE_DIR}/build/xbmc-pvr-addons ${CMAKE_SOURCE_DIR}/../../pvr-addons

--- a/tools/boxeebox/CMakeLists.txt
+++ b/tools/boxeebox/CMakeLists.txt
@@ -148,6 +148,19 @@ set(libs
 	libxml2.so
 	libxslt.so
 	libyajl.so.2
+	libavcodec.so.56
+	libavdevice.so.56
+	libavfilter.so.5
+	libavformat.so.56
+	libpostproc.so.53
+	libavutil.so.54
+	libswresample.so.1
+	libswscale.so.3
+	libgmp.so.10
+	libgnutls.so.28
+	libgnutls-openssl.so.27
+	libhogweed.so.2
+	libnettle.so.4
 	libiconv.so.2
 )
 

--- a/tools/boxeebox/libs/CMakeLists.txt
+++ b/tools/boxeebox/libs/CMakeLists.txt
@@ -22,27 +22,61 @@ string(REPLACE "\n" "" HOSTMACHINE ${HOSTMACHINE})
 include(ExternalProject)
 
 ExternalProject_Add(
+    zlib
+    URL                   http://zlib.net/zlib-1.2.8.tar.gz
+    URL_MD5               44d667c142d7cda120332623eab69f40
+    CONFIGURE_COMMAND     CROSS_PREFIX=${TARGET} AR=${TARGET}-ar CC=${TARGET}-gcc RANLIB=${TARGET}-ranlib <SOURCE_DIR>/configure --uname=Linux --prefix=${SYSROOT}/usr
+    BUILD_COMMAND         ""
+    INSTALL_COMMAND       make ${PARALLEL} install
+    BUILD_IN_SOURCE       1
+)
+
+ExternalProject_Add(
+    iconv
+    URL                   http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz
+    URL_MD5               e34509b1623cec449dfeb73d7ce9c6c6
+    PATCH_COMMAND         COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/libiconv-1-fixes.patch
+    CONFIGURE_COMMAND     ${BASIC_CONF} --enable-extra-encodings
+    BUILD_COMMAND         make
+    DEPENDS               zlib
+)
+
+ExternalProject_Add(
+    ncurses
+    URL                   http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz
+    URL_MD5               8cb9c412e5f2d96bc6f459aa8c6282a1
+    PATCH_COMMAND         patch -p1 < ${CMAKE_SOURCE_DIR}/ncurses-20140308-20140323.patch
+      COMMAND             patch -p1 < ${CMAKE_SOURCE_DIR}/ncurses-gcc-5.patch
+    CONFIGURE_COMMAND     ${BASIC_CONF}
+    BUILD_COMMAND         make
+    INSTALL_COMMAND       make install
+    DEPENDS               zlib iconv
+)
+
+ExternalProject_Add(
     yasm
     URL                   http://www.tortall.net/projects/yasm/releases/yasm-1.2.0.tar.gz
     URL_MD5               4cfc0686cf5350dd1305c4d905eb55a6
     CONFIGURE_COMMAND     ${BASIC_CONF} --disable-warnerror --disable-profiling --disable-gcov --disable-python --disable-python-bindings --enable-nls --disable-rpath --without-dmalloc --with-gnu-ld --without-libiconv-prefix --without-libintl-prefix --disable-debug
     BUILD_COMMAND         make
     INSTALL_COMMAND       make install
+    DEPENDS               zlib iconv ncurses
 )
 
 ExternalProject_Add(
-	libgpg-error
-	URL 			ftp://ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.12.tar.bz2
-	URL_MD5 		8f0eb41a344d19ac2aa9bd101dfb9ce6
-	CONFIGURE_COMMAND 	${BASIC_CONF}
+    libgpg-error
+    URL                   ftp://ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.12.tar.bz2
+    URL_MD5               8f0eb41a344d19ac2aa9bd101dfb9ce6
+    CONFIGURE_COMMAND     ${BASIC_CONF}
+    DEPENDS               zlib iconv ncurses
 )
 
 ExternalProject_Add(
-	libgcrypt
-	URL 			ftp://ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-1.6.1.tar.gz
-	URL_MD5 		d155aa1b06fa879175922ba28f6a6509
-	CONFIGURE_COMMAND 	GPG_ERROR_CONFIG=${TARGET_DIR}/bin/gpg-error-config ${BASIC_CONF} --disable-asm
-	DEPENDS libgpg-error
+    libgcrypt
+    URL                   ftp://ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-1.6.3.tar.gz
+    URL_MD5               de03b867d02fdf115a1bac8bb8b5c3a3
+    CONFIGURE_COMMAND     GPG_ERROR_CONFIG=${TARGET_DIR}/bin/gpg-error-config ${BASIC_CONF} --disable-asm
+    DEPENDS               libgpg-error zlib iconv ncurses
 )
 
 ExternalProject_Add(
@@ -52,6 +86,7 @@ ExternalProject_Add(
     CONFIGURE_COMMAND     ${BASIC_CONF}
     BUILD_COMMAND         make
     INSTALL_COMMAND       make install
+    DEPENDS               zlib iconv ncurses
 )
 
 ExternalProject_Add(
@@ -61,25 +96,27 @@ ExternalProject_Add(
     CONFIGURE_COMMAND     ${BASIC_CONF} --without-python --without-iconv
     BUILD_COMMAND         make
     INSTALL_COMMAND       make install
-)
-
-ExternalProject_Add(
-    ncurses
-    URL                   http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz
-    URL_MD5               8cb9c412e5f2d96bc6f459aa8c6282a1
-    CONFIGURE_COMMAND     ${BASIC_CONF}
-    BUILD_COMMAND         make
-    INSTALL_COMMAND       make install
+    DEPENDS               zlib iconv ncurses
 )
 
 ExternalProject_Add(
     readline
-    URL                   ftp://ftp.cwru.edu/pub/bash/readline-6.2.tar.gz
+    URL                   http://ftp.gnu.org/gnu/readline/readline-6.2.tar.gz
     URL_MD5               67948acb2ca081f23359d0256e9a271c
     CONFIGURE_COMMAND     ${BASIC_CONF} CFLAGS=-I${TARGET_DIR}/include LDFLAGS=-L${TARGET_DIR}/lib --with-curses --without-purify
     BUILD_COMMAND         make
     INSTALL_COMMAND       make install
-	DEPENDS               ncurses
+    DEPENDS               ncurses zlib iconv
+)
+
+ExternalProject_Add(
+    gmp
+    URL                   https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2
+    URL_MD5               b7ff2d88cae7f8085bd5006096eed470
+    CONFIGURE_COMMAND     <SOURCE_DIR>/configure --prefix=${TARGET_DIR} --host=${TARGET} --build=${HOSTMACHINE} --target=${TARGET} CROSS_COMPILE=${TARGET}- LDFLAGS=-L${TARGET_DIR}/lib --enable-shared --enable-cxx --enable-cxx ABI=32
+    BUILD_COMMAND         make ${PARALLEL}
+    INSTALL_COMMAND       make install
+    DEPENDS               zlib iconv ncurses
 )
 
 ExternalProject_Add(
@@ -99,430 +136,397 @@ ExternalProject_Add(
         COMMAND           patch -p1 < ${CMAKE_SOURCE_DIR}/afpfs-ng-patches/11-fix-stat.patch
         COMMAND           patch -p0 < ${CMAKE_SOURCE_DIR}/afpfs-ng-patches/android.patch
         COMMAND           autoreconf -vif
-    CONFIGURE_COMMAND     ${BASIC_CONF} CFLAGS=-I${TARGET_DIR}/include LDFLAGS=-L${TARGET_DIR}/lib ac_cv_func_malloc_0_nonnull=yes --disable-fuse --enable-gcrypt
+    CONFIGURE_COMMAND     ${BASIC_CONF} CFLAGS=-I${TARGET_DIR}/include\ -D_FORTIFY_SOURCE=0 LDFLAGS=-L${TARGET_DIR}/lib ac_cv_func_malloc_0_nonnull=yes --disable-fuse --enable-gcrypt LIBS=-lgmp\ -lpthread\ -lreadline\ -lncurses\ -lgcrypt\ -lgpg-error\ -liconv
     BUILD_COMMAND         make
     INSTALL_COMMAND       make install
     BUILD_IN_SOURCE       1
-    DEPENDS               readline ncurses
+    DEPENDS               readline ncurses libgpg-error libgcrypt zlib iconv gmp
 )
 
 if(ENABLE_MYSQL)
 ExternalProject_Add(
-	mysql
-	URL 		  http://mysql.mirrors.pair.com/Downloads/MySQL-5.1/mysql-5.1.72.tar.gz
-	URL_MD5 	  ed79cd48e3e7402143548917813cdb80
-	PATCH_COMMAND
-	    COMMAND       patch -Np1  < ${CMAKE_SOURCE_DIR}/01-mysqlclient-cross-compile.patch
-	CONFIGURE_COMMAND ac_cv_c_bigendian=no <SOURCE_DIR>/configure CFLAGS=-I${TARGET_DIR}/include LDFLAGS=-L${TARGET_DIR}/lib --prefix=${TARGET_DIR} --host=${TARGET} ac_cv_c_stack_direction=-1 ac_cv_sys_restartable_syscalls=yes --localstatedir=/storage/.mysql --with-unix-socket-path=/var/tmp/mysql.socket --with-tcp-port=3306 --enable-static --disable-shared --with-low-memory --enable-largefile --with-big-tables --with-mysqld-user=mysqld --with-extra-charsets=all --with-extra-charsets=complex --with-named-thread-libs=-lc --with-named-curses-libs=-lncurses --enable-thread-safe-client --enable-assembler --enable-local-infile --without-debug --without-docs --without-man --with-readline --without-libwrap --without-server --without-embedded-server --without-libedit --with-query-cache --with-pthread --with-named-thread-libs=-lpthread
-	BUILD_COMMAND     make -C include my_config.h
-	    COMMAND       make -C mysys libmysys.a
-	    COMMAND       make -C strings libmystrings.a
-	    COMMAND       make -C vio libvio.a
-	    COMMAND       make -C dbug libdbug.a
-	    COMMAND       make -C regex libregex.a
-	    COMMAND       make -C sql gen_lex_hash
-	    COMMAND       make -C mysys libmysys.a
-	    COMMAND       make -C scripts comp_sql
-	    COMMAND       make -C extra comp_err
-	INSTALL_COMMAND   make -C libmysql
-	    COMMAND       make -C libmysql/ install
-	    COMMAND       make -C scripts/ install-binSCRIPTS
-	    COMMAND       make -C include/ install
-	    COMMAND       sudo ln -sf ${SYSROOT}/usr/local/bin/mysql_config /usr/bin/mysql_config
-	    DEPENDS       readline ncurses
+    mysql
+    URL                   http://mysql.mirrors.pair.com/Downloads/MySQL-5.1/mysql-5.1.72.tar.gz
+    URL_MD5               ed79cd48e3e7402143548917813cdb80
+    PATCH_COMMAND
+        COMMAND           patch -Np1  < ${CMAKE_SOURCE_DIR}/01-mysqlclient-cross-compile.patch
+    CONFIGURE_COMMAND     ac_cv_c_bigendian=no ac_cv_header_curses_h={TARGET_DIR}/include/ncurses/curses.h <SOURCE_DIR>/configure CFLAGS=-I${TARGET_DIR}/include LDFLAGS=-L${TARGET_DIR}/lib --prefix=${TARGET_DIR} --host=${TARGET} --build=${HOSTMACHINE} --target=${TARGET} CROSS_COMPILE=${TARGET}- ac_cv_c_stack_direction=-1 ac_cv_sys_restartable_syscalls=yes --with-zlib-dir=${SYSROOT}/usr --localstatedir=/storage/.mysql --with-unix-socket-path=/var/tmp/mysql.socket --with-tcp-port=3306 --enable-static --disable-shared --with-low-memory --enable-largefile --with-big-tables --with-mysqld-user=mysqld --with-extra-charsets=all --with-pthread --with-named-thread-libs=-lpthread --with-extra-charsets=complex --with-named-thread-libs=-lc --with-named-curses-libs=-lncurses --enable-thread-safe-client --enable-assembler --enable-local-infile --without-debug --without-docs --without-man --with-readline --without-libwrap --without-server --without-embedded-server --without-libedit --with-query-cache --with-pthread --with-named-thread-libs=-lpthread --without-plugin-daemon_example --without-plugin-partition --without-plugin-ftexample --without-plugin-archive --without-plugin-blackhole --without-plugin-example --without-plugin-federated --without-plugin-ibmdb2i --without-plugin-innobase --without-plugin-innodb_plugin --without-plugin-ndbcluster
+    BUILD_COMMAND         make
+    INSTALL_COMMAND       make -C libmysql
+        COMMAND           make -C libmysql/ install
+        COMMAND           make -C scripts/ install-binSCRIPTS
+        COMMAND           make -C include/ install
+        COMMAND           cp scripts/mysql_config ${SYSROOT}/usr/local/bin
+    DEPENDS               readline ncurses zlib iconv ncurses
 )
 endif()
 
 ExternalProject_Add(
     libxslt
-    URL               ftp://xmlsoft.org/libxslt/libxslt-1.1.28.tar.gz
-    URL_MD5           9667bf6f9310b957254fdcf6596600b7
-    PATCH_COMMAND     sed -i bak -e "s|runtest$$(EXEEXT)||" "libxslt/Makefile.in"
-	COMMAND        sed -i bak -e "s|testrecurse$$(EXEEXT)||" "libxslt/Makefile.in"
-	COMMAND        sed -i bak -e "s|xsltproc||" "libxslt/Makefile.in"
-    CONFIGURE_COMMAND ${BASIC_CONF} --without-python --with-debug --with-debugger --with-mem-debug --without-crypto --with-libxml-prefix=${TARGET_DIR}
-    BUILD_COMMAND     make
-    INSTALL_COMMAND   make install
-    DEPENDS libxml2
+    URL                   ftp://xmlsoft.org/libxslt/libxslt-1.1.28.tar.gz
+    URL_MD5               9667bf6f9310b957254fdcf6596600b7
+    PATCH_COMMAND         sed -i.bak -e "s|runtest$$(EXEEXT)||" "libxslt/Makefile.in"
+       COMMAND            sed -i.bak -e "s|testrecurse$$(EXEEXT)||" "libxslt/Makefile.in"
+       COMMAND            sed -i.bak -e "s|xsltproc||" "libxslt/Makefile.in"
+    CONFIGURE_COMMAND     ${BASIC_CONF} --without-python --with-debug --with-debugger --with-mem-debug --without-crypto --with-libxml-prefix=${TARGET_DIR}
+    BUILD_COMMAND         make
+    INSTALL_COMMAND       make install
+    DEPENDS               libxml2 zlib iconv ncurses
 )
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-	ExternalProject_Add(
-		iconv
-		URL                  http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz
-		URL_MD5              e34509b1623cec449dfeb73d7ce9c6c6
-		CONFIGURE_COMMAND    ${BASIC_CONF}
-		BUILD_COMMAND        make
+ExternalProject_Add(
+    libusb
+    URL                   http://mirrors.xbmc.org/build-deps/darwin-libs/libusb-0.1.12.tar.gz
+    URL_MD5               caf182cbc7565dac0fd72155919672e6
+    CONFIGURE_COMMAND     <SOURCE_DIR>/configure --prefix=${TARGET_DIR} --host=${TARGET}  --disable-shared --disable-build-docs
+    BUILD_COMMAND         make
+    INSTALL_COMMAND       make install
+    BUILD_IN_SOURCE       1
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    bzip2
+    URL                   http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz
+    URL_MD5               00b516f4704d4a7cb50a1d97e6e8e15b
+    PATCH_COMMAND         sed -e "s,CC=gcc,CC=${TARGET}-gcc," -e "s,RANLIB=ranlib,RANLIB=${TARGET}-ranlib," -e "s,PREFIX=/usr/local,PREFIX=${TARGET_DIR},g" -i.bak Makefile
+    CONFIGURE_COMMAND     ""
+    BUILD_COMMAND         ""
+    INSTALL_COMMAND       make install
+    BUILD_IN_SOURCE       1
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    lzo
+    URL                   http://www.oberhumer.com/opensource/lzo/download/lzo-2.06.tar.gz
+    URL_MD5               95380bd4081f85ef08c5209f4107e9f8
+    CONFIGURE_COMMAND     ${BASIC_CONF}
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    openssl
+    URL                   http://www.openssl.org/source/openssl-1.0.2a.tar.gz
+    URL_MD5               a06c547dac9044161a477211049f60ef
+    CONFIGURE_COMMAND     CC=${TARGET}-gcc RANLIB=${TARGET}-ranlib AR=${TARGET}-ar <SOURCE_DIR>/Configure --prefix=${SYSROOT}/usr/local shared --openssldir=/ --libdir=lib linux-elf threads enable-camellia enable-seed enable-tlsext enable-rfc3779 enable-cms enable-md2 no-krb5 no-mdc2 no-rc5 no-ec no-ec2mno-ecdh no-ecdsa no-srp
+    BUILD_COMMAND         make
+    INSTALL_COMMAND       make install
+    BUILD_IN_SOURCE       1
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    libtiff
+    URL                   http://download.osgeo.org/libtiff/tiff-4.0.3.tar.gz
+    URL_MD5               051c1068e6a0627f461948c365290410
+    CONFIGURE_COMMAND     ${BASIC_CONF}
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    flex
+    URL                   http://sourceforge.net/projects/flex/files/flex-2.5.39.tar.bz2/download
+    URL_MD5               77d44c6bb8c0705e0017ab9a84a1502b
+    PATCH_COMMAND         sed -e "s/AR\ =\ ar/AR\ =\ ${TARGET}-ar/g" -i.bak Makefile.in
+    CONFIGURE_COMMAND     ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes ${BASIC_CONF}
+    BUILD_COMMAND         make ${PARALLEL}
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    expat
+    URL                   http://sourceforge.net/projects/expat/files/expat/2.1.0/expat-2.1.0.tar.gz/download
+    URL_MD5               dd7dab7a5fea97d2a6a43f511449b7cd
+    CONFIGURE_COMMAND     ${BASIC_CONF}
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    yajl
+    GIT_REPOSITORY        http://github.com/lloyd/yajl.git
+    GIT_TAG               2.1.0
+    UPDATE_COMMAND        ""
+    CONFIGURE_COMMAND     ${BASIC_CMAKE}
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    tinyxml
+    URL                   http://sourceforge.net/projects/tinyxml/files/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz/download
+    URL_MD5               c1b864c96804a10526540c664ade67f0
+    CONFIGURE_COMMAND     ""
+    BUILD_COMMAND         make CXX=${TARGET}-g++ LD=${TARGET}-g++ CXXFLAGS=-DTIXML_USE_STL
+        COMMAND           ${TARGET}-ar r libtinyxml.a tinyxml.o tinystr.o tinyxmlerror.o tinyxmlparser.o
+    INSTALL_COMMAND       ${CMAKE_COMMAND} -E copy libtinyxml.a ${TARGET_DIR}/lib/
+        COMMAND           ${CMAKE_COMMAND} -E copy tinyxml.h ${TARGET_DIR}/include
+        COMMAND           ${CMAKE_COMMAND} -E copy tinystr.h ${TARGET_DIR}/include
+    BUILD_IN_SOURCE       1
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    sqlite
+    URL                   http://www.sqlite.org/2015/sqlite-autoconf-3080900.tar.gz
+    URL_MD5               6a18d4609852f4b63f812a1059df468f
+    CONFIGURE_COMMAND     <SOURCE_DIR>/configure --prefix=${TARGET_DIR} --host=${TARGET}  --disable-shared --enable-static --enable-threadsafe --disable-readline --enable-dynamic-extensions
+    BUILD_COMMAND         make CXXFLAGS+=-DSQLITE_ENABLE_COLUMN_METADATA=1 CFLAGS+=-DSQLITE_TEMP_STORE=3  CFLAGS+=-DSQLITE_ENABLE_STAT3 CFLAGS+=-DSQLITE_DEFAULT_MMAP_SIZE=268435456
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    libcdio
+    URL                   http://ftp.gnu.org/gnu/libcdio/libcdio-0.90.tar.gz
+    URL_MD5               1b245b023fb03a58d030fd2800db3247
+    CONFIGURE_COMMAND     ${BASIC_CONF} --disable-example-progs --without-cpp-progs --without-cd-drive --without-cd-info --without-cdda-player  --without-cd-read --without-iso-info --without-iso-read
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    libcddb
+    URL                   http://prdownloads.sourceforge.net/libcddb/libcddb-1.3.2.tar.bz2
+    URL_MD5               8bb4a6f542197e8e9648ae597cd6bc8a
+    CONFIGURE_COMMAND     ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes ${BASIC_CONF}
+    DEPENDS               libcdio zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    pcre
+    URL                   http://sourceforge.net/projects/pcre/files/pcre/8.37/pcre-8.37.tar.bz2/download
+    URL_MD5               ed91be292cb01d21bc7e526816c26981
+    CONFIGURE_COMMAND     <SOURCE_DIR>/configure --prefix=${TARGET_DIR} --host=${TARGET}  --disable-shared --enable-static --enable-utf8 --enable-unicode-properties --with-gnu-ld
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    taglib
+    URL                   http://taglib.github.io/releases/taglib-1.8.tar.gz
+    URL_MD5               dcb8bd1b756f2843e18b1fdf3aaeee15
+    PATCH_COMMAND         sed -e "54,61d" -i.bak taglib/toolkit/taglib.h
+    CONFIGURE_COMMAND     ${BASIC_CMAKE} -DENABLE_STATIC=ON -DENABLE_STATIC_RUNTIME=ON
+    DEPENDS               zlib pcre iconv
+)
+
+ExternalProject_Add(
+    libpng
+    URL                   http://sourceforge.net/projects/libpng/files/libpng15/older-releases/1.5.13/libpng-1.5.13.tar.gz/download
+    URL_MD5               9c5a584d4eb5fe40d0f1bc2090112c65
+    CONFIGURE_COMMAND     CFLAGS=-I${TARGET_DIR}/include LDFLAGS=-L${TARGET_DIR}/lib ${BASIC_CONF}
+    BUILD_COMMAND         CFLAGS=-I${TARGET_DIR}/include make ${PARALLEL}
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    libmicrohttpd
+    URL                   ftp://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.42.tar.gz
+    URL_MD5               3b9cf0b67fc8ebc9e69f53c6bc84a88d
+    PATCH_COMMAND         sed -e "s,#ifdef LINUX,#ifdef LINUX\\n#define SOCK_NONBLOCK	O_NONBLOCK\\n#define EPOLL_CLOEXEC O_CLOEXEC," -e "s,epoll_create1,epoll_create,g" -i.bak src/microhttpd/daemon.c
+    CONFIGURE_COMMAND     CFLAGS=-I{TARGET_DIR}/include LDFLAGS=-lc ac_cv_path_LIBGCRYPT_CONFIG=${SYSROOT}/usr/local/bin/ <SOURCE_DIR>/configure --prefix=${TARGET_DIR} --host=${TARGET} --disable-shared --enable-static --disable-curl --disable-https --disable-doc --disable-examples --disable-spdy
+    DEPENDS               libgcrypt zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    freetype2
+    URL                   http://sourceforge.net/projects/freetype/files/freetype2/2.5.4/freetype-2.5.4.tar.gz/download
+    URL_MD5               99c5ab378218218f25afcd5171898faf
+    CONFIGURE_COMMAND     ac_cv_env_LIBPNG_CFLAGS_value=-I${SYSROOT}/usr/local/include ac_cv_env_LIBPNG_LIBS_value=-L${SYSROOT}/usr/local/lib ${BASIC_CONF}
+    BUILD_COMMAND         make ${PARALLEL}
+    DEPENDS               libpng zlib ncurses
+)
+
+ExternalProject_Add(
+    gdbm
+    URL                   ftp://ftp.gnu.org/gnu/gdbm/gdbm-1.11.tar.gz
+    URL_MD5               72c832680cf0999caedbe5b265c8c1bd
+    PATCH_COMMAND         sed -e "s,finish_cmds=.*,,g" -i.bak configure
+        COMMAND           sed -e "s,-o .(BINOWN) -g .(BINGRP),,g" -i.bak Makefile.in
+    CONFIGURE_COMMAND     ${BASIC_CONF}
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    fribidi
+    URL                   http://fribidi.org/download/fribidi-0.19.6.tar.bz2
+    URL_MD5               ce93d862344991173dabb609bf93ca1d
+    CONFIGURE_COMMAND     ${BASIC_CONF} --without-glib --disable-debug --disable-deprecated --disable-silent-rules --enable-malloc --enable-charsets --with-gnu-ld
+    DEPENDS               freetype2 zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    fontconfig
+    URL                   http://www.freedesktop.org/software/fontconfig/release/fontconfig-2.11.1.tar.gz
+    URL_MD5               e75e303b4f7756c2b16203a57ac87eba
+    CONFIGURE_COMMAND     ${BASIC_CONF} --with-default-fonts=/usr/share/fonts/liberation --disable-libxml2 --disable-docs --with-arch=i686 ac_cv_path_FREETYPE_CONFIG=${SYSROOT}/usr/local/bin/freetype-config
+    DEPENDS               fribidi freetype2 zlib expat iconv ncurses
+)
+
+ExternalProject_Add(
+    libjpeg-turbo
+    URL                   http://sourceforge.net/projects/libjpeg-turbo/files/1.4.0/libjpeg-turbo-1.4.0.tar.gz/download
+    URL_MD5               039153dabe61e1ac8d9323b5522b56b0
+    CONFIGURE_COMMAND     <SOURCE_DIR>/configure --prefix=${TARGET_DIR} --host=${TARGET} --disable-shared --enable-static --disable-nls --with-jpeg8 --without-simd
+    BUILD_COMMAND         make
+    INSTALL_COMMAND       make install
+    BUILD_IN_SOURCE       1
+    DEPENDS               zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    jasper
+    URL                   http://www.ece.uvic.ca/~frodo/jasper/software/jasper-1.900.1.zip
+    URL_MD5               a342b2b4495b3e1394e161eb5d85d754
+    CONFIGURE_COMMAND     ${BASIC_CONF}
+    BUILD_COMMAND         make
+    INSTALL_COMMAND       make install
+    DEPENDS               libjpeg-turbo zlib iconv ncurses
 	)
-	set(ICONV_TYPE yes)
-else()
-	add_custom_target(iconv COMMENT "iconv isn't built on linux, because it isn't needed (???)")
-	set(ICONV_TYPE no)
-endif()
 
 ExternalProject_Add(
-	libenca
-	URL                 https://github.com/nijel/enca/archive/1.16.tar.gz
-	URL_MD5             4f39869a757e96deb372884e6f474a27
-	PATCH_COMMAND       sed -i bak -e "s,.(AM_V_CC).(COMPILE),cc," "tools/Makefile.in"
-	COMMAND             sed -i bak -e "s,.(AM_V_CCLD).(LINK),cc -o \$@," "tools/Makefile.in" VERBATIM
-	CONFIGURE_COMMAND   ac_cv_file__dev_random=yes ac_cv_file__dev_urandom=no ac_cv_file__dev_srandom=no ac_cv_file__dev_arandom=no ${BASIC_CONF} --disable-external --without-librecode --disable-rpath --with-gnu-ld
-	BUILD_COMMAND       make
-	BUILD_IN_SOURCE     1
-	DEPENDS             iconv
+    fftw3
+    URL                   http://www.fftw.org/fftw-3.3.4.tar.gz
+    URL_MD5               2edab8c06b24feeb3b82bbb3ebf3e7b3
+    CONFIGURE_COMMAND     ${BASIC_CONF}
+    BUILD_COMMAND         make ${PARALLEL}
+    DEPENDS               zlib iconv ncurses
 )
 
 ExternalProject_Add(
-	libusb
-	URL                 http://mirrors.xbmc.org/build-deps/darwin-libs/libusb-0.1.12.tar.gz
-	URL_MD5             caf182cbc7565dac0fd72155919672e6
-	CONFIGURE_COMMAND   <SOURCE_DIR>/configure --prefix=${TARGET_DIR} --host=${TARGET}  --disable-shared --disable-build-docs
-	BUILD_COMMAND       make
-    INSTALL_COMMAND         make install
-    BUILD_IN_SOURCE         1
+    libogg
+    URL                   http://downloads.xiph.org/releases/ogg/libogg-1.3.1.tar.gz
+    URL_MD5               ba526cd8f4403a5d351a9efaa8608fbc
+    CONFIGURE_COMMAND     ${BASIC_CONF}
+    BUILD_COMMAND         make ${PARALLEL}
+    DEPENDS               zlib iconv ncurses
 )
 
 ExternalProject_Add(
-	bzip2
-	URL                 http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz
-	URL_MD5             00b516f4704d4a7cb50a1d97e6e8e15b
-	PATCH_COMMAND       sed -e "s,CC=gcc,CC=${TARGET}-gcc," -e "s,RANLIB=ranlib,RANLIB=${TARGET}-ranlib," -e "s,PREFIX=/usr/local,PREFIX=${TARGET_DIR},g" -i bak Makefile
-	CONFIGURE_COMMAND   ""
-	BUILD_COMMAND       ""
-	INSTALL_COMMAND     make install
-	BUILD_IN_SOURCE     1
+    libvorbis
+    URL                   http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.3.tar.gz
+    URL_MD5               6b1a36f0d72332fae5130688e65efe1f
+    CONFIGURE_COMMAND     ${BASIC_CONF}
+    BUILD_COMMAND         make ${PARALLEL}
+    DEPENDS               libogg zlib iconv ncurses
 )
 
 ExternalProject_Add(
-	lzo
-	URL                 http://www.oberhumer.com/opensource/lzo/download/lzo-2.06.tar.gz
-	URL_MD5             95380bd4081f85ef08c5209f4107e9f8
-	CONFIGURE_COMMAND   ${BASIC_CONF}
+    flac
+    URL                   http://downloads.xiph.org/releases/flac/flac-1.2.1.tar.gz
+    URL_MD5               153c8b15a54da428d1f0fadc756c22c7
+    CONFIGURE_COMMAND     ${BASIC_CONF} --disable-oggtest --disable-xmms-plugin
+    BUILD_COMMAND         ""
+    INSTALL_COMMAND       make -C src ${PARALLEL} install
+        COMMAND           make -C include ${PARALLEL} install
+    DEPENDS               libvorbis zlib iconv ncurses
 )
 
 ExternalProject_Add(
-	zlib
-	URL                     http://zlib.net/zlib-1.2.8.tar.gz
-	URL_MD5                 44d667c142d7cda120332623eab69f40
-	CONFIGURE_COMMAND	CROSS_PREFIX=${TARGET} AR=${TARGET}-ar CC=${TARGET}-gcc RANLIB=${TARGET}-ranlib <SOURCE_DIR>/configure --uname=Linux --prefix=${SYSROOT}/usr
-	BUILD_COMMAND 		""
-	INSTALL_COMMAND 	make ${PARALLEL} install
-	BUILD_IN_SOURCE 	1
+    libao
+    URL                   http://downloads.xiph.org/releases/ao/libao-1.2.0.tar.gz
+    URL_MD5               9f5dd20d7e95fd0dd72df5353829f097
+    CONFIGURE_COMMAND     ${BASIC_CONF} --disable-pulse
+    BUILD_COMMAND         make ${PARALLEL}
+    DEPENDS               zlib iconv ncurses
 )
 
-ExternalProject_Add(
-	openssl
-	URL                     https://www.openssl.org/source/openssl-1.0.1j.tar.gz
-	URL_MD5                 f7175c9cd3c39bb1907ac8bba9df8ed3
-	PATCH_COMMAND           patch -p1 < ${CMAKE_SOURCE_DIR}/openssl-patches/openssl-cflags.patch
-	  COMMAND               patch -p1 < ${CMAKE_SOURCE_DIR}/openssl-patches/openssl-nodocs.patch
-	CONFIGURE_COMMAND 	CC=${TARGET}-gcc RANLIB=${TARGET}-ranlib AR=${TARGET}-ar <SOURCE_DIR>/Configure --prefix=${SYSROOT}/usr/local shared --openssldir=/ --libdir=lib linux-elf threads enable-camellia enable-seed enable-tlsext enable-rfc3779 enable-cms enable-md2 no-krb5 no-mdc2 no-rc5 no-ec no-ec2mno-ecdh no-ecdsa no-srp
-	BUILD_COMMAND           make
-	INSTALL_COMMAND 	make install
-	BUILD_IN_SOURCE 	1
-	DEPENDS                 zlib
-)
-
-ExternalProject_Add(
-	libtiff
-	URL			http://download.osgeo.org/libtiff/tiff-4.0.3.tar.gz
-	URL_MD5			051c1068e6a0627f461948c365290410
-	CONFIGURE_COMMAND	${BASIC_CONF}
-)
-
-ExternalProject_Add(
-	flex
-	URL			http://sourceforge.net/projects/flex/files/flex-2.5.39.tar.bz2/download
-	URL_MD5			77d44c6bb8c0705e0017ab9a84a1502b
-	PATCH_COMMAND 		sed -e "s/AR\ =\ ar/AR\ =\ ${TARGET}-ar/g" -i bak Makefile.in
-	CONFIGURE_COMMAND	ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes ${BASIC_CONF}
-	BUILD_COMMAND 		make ${PARALLEL}
-)
-
-ExternalProject_Add(
-	expat
-	URL			http://sourceforge.net/projects/expat/files/expat/2.1.0/expat-2.1.0.tar.gz/download
-	URL_MD5			dd7dab7a5fea97d2a6a43f511449b7cd
-	CONFIGURE_COMMAND	${BASIC_CONF}
-)
-
-ExternalProject_Add(
-	yajl
-	GIT_REPOSITORY  	https://github.com/lloyd/yajl.git
-	GIT_TAG			2.1.0
-	UPDATE_COMMAND           ""
-	CONFIGURE_COMMAND 	${BASIC_CMAKE}
-)
-
-ExternalProject_Add(
-	tinyxml
-	URL			http://sourceforge.net/projects/tinyxml/files/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz/download
-	URL_MD5			c1b864c96804a10526540c664ade67f0
-	CONFIGURE_COMMAND 	""
-	BUILD_COMMAND 		make CXX=${TARGET}-g++ LD=${TARGET}-g++ CXXFLAGS=-DTIXML_USE_STL
-		COMMAND ${TARGET}-ar r libtinyxml.a tinyxml.o tinystr.o tinyxmlerror.o tinyxmlparser.o
-	INSTALL_COMMAND ${CMAKE_COMMAND} -E copy libtinyxml.a ${TARGET_DIR}/lib/
-		COMMAND ${CMAKE_COMMAND} -E copy tinyxml.h ${TARGET_DIR}/include
-		COMMAND ${CMAKE_COMMAND} -E copy tinystr.h ${TARGET_DIR}/include
-	BUILD_IN_SOURCE 	1
-)
-
-ExternalProject_Add(
-	sqlite
-	URL 		    http://www.sqlite.org/2014/sqlite-autoconf-3080701.tar.gz
-	URL_MD5 	    8ee4541ebb3e5739e7ef5e9046e30063
-	CONFIGURE_COMMAND   <SOURCE_DIR>/configure --prefix=${TARGET_DIR} --host=${TARGET}  --disable-shared --enable-static --enable-threadsafe --disable-readline --enable-dynamic-extensions
-	BUILD_COMMAND       make CXXFLAGS+=-DSQLITE_ENABLE_COLUMN_METADATA=1 CFLAGS+=-DSQLITE_TEMP_STORE=3  CFLAGS+=-DSQLITE_ENABLE_STAT3 CFLAGS+=-DSQLITE_DEFAULT_MMAP_SIZE=268435456
-)
-
-ExternalProject_Add(
-	libcdio
-	URL			http://ftp.gnu.org/gnu/libcdio/libcdio-0.90.tar.gz
-	URL_MD5			1b245b023fb03a58d030fd2800db3247
-	CONFIGURE_COMMAND 	${BASIC_CONF} --disable-example-progs --without-cpp-progs --without-cd-drive --without-cd-info --without-cdda-player  --without-cd-read --without-iso-info --without-iso-read
-)
-
-ExternalProject_Add(
-        libcddb
-        URL                   http://prdownloads.sourceforge.net/libcddb/libcddb-1.3.2.tar.bz2
-	URL_MD5               8bb4a6f542197e8e9648ae597cd6bc8a
-	CONFIGURE_COMMAND     ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes ${BASIC_CONF}
-	DEPENDS               libcdio
-)
-
-ExternalProject_Add(
-	taglib
-	URL 			http://taglib.github.io/releases/taglib-1.8.tar.gz
-	URL_MD5 		dcb8bd1b756f2843e18b1fdf3aaeee15
-	PATCH_COMMAND 		sed -e "54,61d" -i bak taglib/toolkit/taglib.h
-	CONFIGURE_COMMAND	${BASIC_CMAKE}
-)
-
-ExternalProject_Add(
-	libpng
-	URL 			http://sourceforge.net/projects/libpng/files/libpng15/older-releases/1.5.13/libpng-1.5.13.tar.gz/download
-	URL_MD5 		9c5a584d4eb5fe40d0f1bc2090112c65
-	CONFIGURE_COMMAND 	CFLAGS=-I${TARGET_DIR}/include LDFLAGS=-L${TARGET_DIR}/lib ${BASIC_CONF}
-	BUILD_COMMAND		CFLAGS=-I${TARGET_DIR}/include make ${PARALLEL}
-	DEPENDS			zlib
-)
-
-ExternalProject_Add(
-	pcre
-	URL 			http://sourceforge.net/projects/pcre/files/pcre/8.36/pcre-8.36.tar.bz2/download
-	URL_MD5 		b767bc9af0c20bc9c1fe403b0d41ad97
-	CONFIGURE_COMMAND 	${BASIC_CONF} --enable-utf8 --enable-unicode-properties
-)
-
-ExternalProject_Add(
-	libmicrohttpd
-	URL 			ftp://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.34.tar.gz
-	URL_MD5 		2947eee13c2c8affb95023a0cb6fda0c
-	PATCH_COMMAND 		sed -e "s,#ifdef LINUX,#ifdef LINUX\\n#define SOCK_NONBLOCK	O_NONBLOCK\\n#define EPOLL_CLOEXEC O_CLOEXEC," -e "s,epoll_create1,epoll_create,g" -i bak src/microhttpd/daemon.c
-	CONFIGURE_COMMAND 	CFLAGS=-I{TARGET_DIR}/include LDFLAGS=-lc ac_cv_path_LIBGCRYPT_CONFIG=${SYSROOT}/usr/local/bin/ <SOURCE_DIR>/configure --prefix=${TARGET_DIR} --host=${TARGET} --disable-shared --enable-static --disable-curl --disable-https
-	DEPENDS 		libgcrypt
-)
-
-ExternalProject_Add(
-	freetype2
-	URL 			http://sourceforge.net/projects/freetype/files/freetype2/2.5.3/freetype-2.5.3.tar.gz/download
-	URL_MD5 		cafe9f210e45360279c730d27bf071e9
-	CONFIGURE_COMMAND 	LIBPNG_CFLAGS=-I${SYSROOT}/usr/local/include LIBPNG_LDFLAGS=-L${SYSROOT}/usr/local/lib ${BASIC_CONF}
-	BUILD_COMMAND		make ${PARALLEL}
-	DEPENDS                 libpng
-)
-
-ExternalProject_Add(
-	gdbm
-	URL 			ftp://ftp.gnu.org/gnu/gdbm/gdbm-1.11.tar.gz
-	URL_MD5 		72c832680cf0999caedbe5b265c8c1bd
-	PATCH_COMMAND		sed -e "s,finish_cmds=.*,,g" -i bak configure
-	   COMMAND 	        sed -e "s,-o .(BINOWN) -g .(BINGRP),,g" -i bak Makefile.in
-	CONFIGURE_COMMAND 	${BASIC_CONF}
-)
-
-ExternalProject_Add(
-	fribidi
-	URL 			http://fribidi.org/download/fribidi-0.19.6.tar.bz2
-	URL_MD5 		ce93d862344991173dabb609bf93ca1d
-	CONFIGURE_COMMAND 	${BASIC_CONF} --without-glib --disable-debug --disable-deprecated --disable-silent-rules --enable-malloc --enable-charsets --with-gnu-ld
-	DEPENDS			freetype2
-)
-
-ExternalProject_Add(
-	fontconfig
-	URL 			http://www.freedesktop.org/software/fontconfig/release/fontconfig-2.11.1.tar.gz
-	URL_MD5 		e75e303b4f7756c2b16203a57ac87eba
-	CONFIGURE_COMMAND 	${BASIC_CONF} --with-default-fonts=/usr/share/fonts/liberation --disable-docs --without-add-fonts --disable-dependency-tracking ac_cv_path_FREETYPE_CONFIG=${SYSROOT}/usr/local/bin/freetype-config
-	DEPENDS fribidi freetype2 zlib expat libxml2
-)
-
-ExternalProject_Add(
-	libjpeg-turbo
-	URL 			http://sourceforge.net/projects/libjpeg-turbo/files/1.3.1/libjpeg-turbo-1.3.1.tar.gz/download
-	URL_MD5 		2c3a68129dac443a72815ff5bb374b05
-	CONFIGURE_COMMAND       <SOURCE_DIR>/configure --prefix=${TARGET_DIR} --host=${TARGET} --disable-shared --enable-static --disable-nls --with-jpeg8 --without-simd
-	BUILD_COMMAND           make
-	INSTALL_COMMAND         make install
-	BUILD_IN_SOURCE         1
-	DEPENDS                 yasm
-)
-
-ExternalProject_Add(
-	jasper
-	URL 			http://www.ece.uvic.ca/~frodo/jasper/software/jasper-1.900.1.zip
-	URL_MD5 		a342b2b4495b3e1394e161eb5d85d754
-	CONFIGURE_COMMAND 	${BASIC_CONF}
-	BUILD_COMMAND 		make ${PARALLEL}
-	DEPENDS                 libjpeg-turbo
-)
-
-ExternalProject_Add(
-	fftw3
-	URL 			http://www.fftw.org/fftw-3.3.4.tar.gz
-	URL_MD5 		2edab8c06b24feeb3b82bbb3ebf3e7b3
-	CONFIGURE_COMMAND 	${BASIC_CONF}
-	BUILD_COMMAND 		make ${PARALLEL}
-)
-
-ExternalProject_Add(
-	libogg
-	URL 			http://downloads.xiph.org/releases/ogg/libogg-1.3.1.tar.gz
-	URL_MD5 		ba526cd8f4403a5d351a9efaa8608fbc
-	CONFIGURE_COMMAND 	${BASIC_CONF}
-	BUILD_COMMAND 		make ${PARALLEL}
-)
-
-ExternalProject_Add(
-	libvorbis
-	URL 			http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.3.tar.gz
-	URL_MD5 		6b1a36f0d72332fae5130688e65efe1f
-	CONFIGURE_COMMAND 	${BASIC_CONF}
-	BUILD_COMMAND 		make ${PARALLEL}
-	DEPENDS libogg
-)
-
-ExternalProject_Add(
-	flac
-	URL 			http://downloads.xiph.org/releases/flac/flac-1.2.1.tar.gz
-	URL_MD5 		153c8b15a54da428d1f0fadc756c22c7
-	CONFIGURE_COMMAND 	${BASIC_CONF} --disable-oggtest --disable-xmms-plugin
-	BUILD_COMMAND 		""
-	INSTALL_COMMAND		make -C src ${PARALLEL} install
-		COMMAND 	make -C include ${PARALLEL} install
-	DEPENDS libvorbis
-)
-
-ExternalProject_Add(
-	libao
-	URL 			http://downloads.xiph.org/releases/ao/libao-1.2.0.tar.gz
-	URL_MD5 		9f5dd20d7e95fd0dd72df5353829f097
-	CONFIGURE_COMMAND 	${BASIC_CONF} --disable-pulse
-	BUILD_COMMAND 		make ${PARALLEL}
-)
-
-ExternalProject_Add(
-	libass
-	GIT_REPOSITORY   	https://github.com/libass/libass.git
-	GIT_TAG                 0.12.0
-	UPDATE_COMMAND           ""
-	PATCH_COMMAND           ./autogen.sh
-	CONFIGURE_COMMAND 	${BASIC_CONF} --with-gnu-ld --enable-enca --enable-fontconfig --disable-harfbuzz --disable-silent-rules --enable-asm --disable-test
-	DEPENDS libpng libenca fribidi freetype2 fontconfig yasm
-)
 # TODO:Fails due to libSDL
 ExternalProject_Add(
-	libmpeg2
-	URL 			http://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz
-	URL_MD5 		0f92c7454e58379b4a5a378485bbd8ef
+    libmpeg2
+    URL                   http://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz
+    URL_MD5               0f92c7454e58379b4a5a378485bbd8ef
     PATCH_COMMAND
-	COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/libmpeg2-patches/01-libmpeg2-add-asm-leading-underscores.patch
-	COMMAND patch -p0 < ${CMAKE_SOURCE_DIR}/libmpeg2-patches/02-neon.patch
-	COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/libmpeg2-patches/03-config-fix.patch
-	COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/libmpeg2-patches/04-clang-fix.patch
-	CONFIGURE_COMMAND 	${BASIC_CONF} --disable-sdl
+    COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/libmpeg2-patches/01-libmpeg2-add-asm-leading-underscores.patch
+    COMMAND patch -p0 < ${CMAKE_SOURCE_DIR}/libmpeg2-patches/02-neon.patch
+    COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/libmpeg2-patches/03-config-fix.patch
+    COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/libmpeg2-patches/04-clang-fix.patch
+    CONFIGURE_COMMAND 	${BASIC_CONF} --disable-sdl
+    DEPENDS               zlib iconv ncurses
 )
 
 ExternalProject_Add(
-	libmodplug
-	URL 			http://sourceforge.net/projects/modplug-xmms/files/libmodplug/0.8.8.5/libmodplug-0.8.8.5.tar.gz/download
-	URL_MD5 		5f30241db109d647781b784e62ddfaa1
-	CONFIGURE_COMMAND 	${BASIC_CONF}
+    libmodplug
+    URL                   http://sourceforge.net/projects/modplug-xmms/files/libmodplug/0.8.8.5/libmodplug-0.8.8.5.tar.gz/download
+    URL_MD5               5f30241db109d647781b784e62ddfaa1
+    CONFIGURE_COMMAND     ${BASIC_CONF}
+    DEPENDS               zlib iconv ncurses
 )
 
 ExternalProject_Add(
     libbluray
-    URL                         ftp://ftp.videolan.org/pub/videolan/libbluray/0.6.2/libbluray-0.6.2.tar.bz2
-    URL_MD5                     f4d2f2cab53f976cbb22cbae069057bd
-    CONFIGURE_COMMAND           ${BASIC_CONF} --disable-examples --disable-doxygen-doc
-    BUILD_COMMAND               make
-    INSTALL_COMMAND             make install
-    DEPENDS                     libxml2  freetype2
+    URL                   ftp://ftp.videolan.org/pub/videolan/libbluray/0.7.0/libbluray-0.7.0.tar.bz2
+    URL_MD5               efad766330164f0c7c7cb18f66389870
+    CONFIGURE_COMMAND     ${BASIC_CONF} --disable-examples --disable-doxygen-doc
+    BUILD_COMMAND         make
+    INSTALL_COMMAND       make install
+    DEPENDS               libxml2  freetype2 zlib iconv ncurses
 )
 
 ExternalProject_Add(
-	libssh
-	URL                     http://git.libssh.org/projects/libssh.git/snapshot/libssh-0.6.3.tar.gz
-	URL_MD5                 5b0fd1dbf2effef2322f6251f6c7ca11
-	PATCH_COMMAND 		sed -e "s,add_subdirectory\(examples\),,g" -i bak CMakeLists.txt
-	CONFIGURE_COMMAND 	${BASIC_CMAKE} -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} -DWITH_STATIC_LIB=1 -DWITH_SERVER=OFF  -DWITH_GCRYPT=OFF -DCMAKE_SHARED_LINKER_FLAGS=-ldl -DCMAKE_EXE_LINKER_FLAGS=-ldl
-	BUILD_COMMAND 		""
-	INSTALL_COMMAND 	make install
-	DEPENDS                 openssl
+    libssh
+    URL                   http://git.libssh.org/projects/libssh.git/snapshot/libssh-a48711ae7ef890c94e2a824afb899df385c406ee.tar.gz
+    URL_MD5               f64dd11d03085b0eeb68a03aa2b620d4
+    PATCH_COMMAND
+    COMMAND               patch -p0 < ${CMAKE_SOURCE_DIR}/md5.patch
+    COMMAND               sed -e "s,add_subdirectory\(examples\),,g" -i.bak CMakeLists.txt
+    COMMAND               sed -i.bak -e "s|-fstack-protector|-fnostack-protector|" "cmake/Modules/DefineCompilerFlags.cmake"	
+    CONFIGURE_COMMAND     ${BASIC_CMAKE} -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} -DWITH_STATIC_LIB=1 -DWITH_SERVER=OFF  -DWITH_GCRYPT=OFF -DWITH_EXAMPLES=0 -DTHREADS_PTHREAD_ARG=0 -DCMAKE_SHARED_LINKER_FLAGS=-ldl -DCMAKE_EXE_LINKER_FLAGS=-ldl
+    BUILD_COMMAND         ""
+    INSTALL_COMMAND       make install
+    DEPENDS               openssl zlib iconv ncurses
 )
 
 ExternalProject_Add(
-	util-linux
-	URL                     https://www.kernel.org/pub/linux/utils/util-linux/v2.25/util-linux-2.25.2.tar.gz
-	URL_MD5                 f4b25b1c89e9021cc19911e8a2d2c2e5
-	CONFIGURE_COMMAND	${BASIC_CONF} --without-ncurses --without-python
-	BUILD_COMMAND		""
-	INSTALL_COMMAND		make install-uuidincHEADERS
+    util-linux
+	URL                   http://www.kernel.org/pub/linux/utils/util-linux/v2.25/util-linux-2.25.2.tar.gz
+    URL_MD5               f4b25b1c89e9021cc19911e8a2d2c2e5
+    CONFIGURE_COMMAND     ${BASIC_CONF} --without-ncurses --without-python
+    BUILD_COMMAND         ""
+    INSTALL_COMMAND       make install-uuidincHEADERS
+    DEPENDS               zlib iconv ncurses
 )
 
 ExternalProject_Add(
-	samba
-	URL                     http://ftp.samba.org/pub/samba/stable/samba-3.6.24.tar.gz
-	URL_MD5                 d98425c0c2b73e08f048d31ffc727fb0
-	CONFIGURE_COMMAND	CC=${TARGET}-gcc CFLAGS=-I${SYSROOT}/usr/local/include LDFLAGS=-L${SYSROOT}/usr/local/lib ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/source3 ./configure --prefix=${TARGET_DIR} --host=${TARGET} samba_cv_CC_NEGATIVE_ENUM_VALUES=yes libreplace_cv_HAVE_GETADDRINFO=no ac_cv_file__proc_sys_kernel_core_pattern=yes  samba_cv_HAVE_STAT_ST_FLAGS=no samba_cv_DARWIN_INITGROUPS=no --without-ldap --without-krb5 --without-ads --disable-cups --enable-swat=no --with-winbind=no --without-dnsupdate --without-libsmbsharemodes --without-pam --without-pam_smbpass --without-libaddns
- 	BUILD_COMMAND 		${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/source3 make ${PARALLEL} libsmbclient libtalloc libtevent libtdb
-	INSTALL_COMMAND 	${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/source3 make ${PARALLEL} installlibsmbclient installlibtalloc installlibtevent installlibtdb
-	BUILD_IN_SOURCE 	1
-	DEPENDS 		util-linux
+    samba
+    URL                   http://ftp.samba.org/pub/samba/stable/samba-3.6.24.tar.gz
+    URL_MD5               d98425c0c2b73e08f048d31ffc727fb0
+    CONFIGURE_COMMAND     CC=${TARGET}-gcc CFLAGS=-I${SYSROOT}/usr/local/include LDFLAGS=-L${SYSROOT}/usr/local/lib ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/source3 ./configure --prefix=${TARGET_DIR} --host=${TARGET} samba_cv_CC_NEGATIVE_ENUM_VALUES=yes libreplace_cv_HAVE_GETADDRINFO=no ac_cv_file__proc_sys_kernel_core_pattern=yes  samba_cv_HAVE_STAT_ST_FLAGS=no samba_cv_DARWIN_INITGROUPS=no --without-ldap --without-krb5 --without-ads --disable-cups --enable-swat=no --with-winbind=no --without-dnsupdate --without-libsmbsharemodes --without-pam --without-pam_smbpass --without-libaddns
+    BUILD_COMMAND         ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/source3 make ${PARALLEL} libsmbclient libtalloc libtevent libtdb
+    INSTALL_COMMAND       ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/source3 make ${PARALLEL} installlibsmbclient installlibtalloc installlibtevent installlibtdb
+    BUILD_IN_SOURCE       1
+    DEPENDS               util-linux zlib iconv ncurses
 )
 
 ExternalProject_Add(
-        nfs
-        GIT_REPOSITORY          https://github.com/sahlberg/libnfs.git
-        GIT_TAG                 4a58e6145568fd21ef956ae6ac3d3c37ef209a57
-        UPDATE_COMMAND          ""
-        PATCH_COMMAND           ./bootstrap
-        CONFIGURE_COMMAND       ${BASIC_CONF} --disable-examples --disable-tirpc
-        BUILD_COMMAND           make
-        INSTALL_COMMAND         make install
-        BUILD_IN_SOURCE         1
+    nfs
+    GIT_REPOSITORY        https://github.com/sahlberg/libnfs.git
+    GIT_TAG               4a58e6145568fd21ef956ae6ac3d3c37ef209a57
+    UPDATE_COMMAND        ""
+    PATCH_COMMAND         ./bootstrap
+    CONFIGURE_COMMAND     ${BASIC_CONF} --disable-examples --disable-tirpc
+    BUILD_COMMAND         make
+    INSTALL_COMMAND       make install
+    BUILD_IN_SOURCE       1
 )
 
 ExternalProject_Add(
-        rtmpdump
-        GIT_REPOSITORY          https://github.com/BurntSushi/rtmpdump-ksv.git
-        CONFIGURE_COMMAND       ""
-        UPDATE_COMMAND          ""
-        BUILD_COMMAND           make CRYPTO=OPENSSL DESTDIR=${SYSROOT} LIBS_posix=-L${TARGET_DIR}/lib XLIBS=-ldl INC=-I${TARGET_DIR}/include CROSS_COMPILE=${TARGET}-
-        INSTALL_COMMAND         make install DESTDIR=${SYSROOT}
-        BUILD_IN_SOURCE         1
-        DEPENDS                 zlib openssl
+    rtmpdump
+    GIT_REPOSITORY        https://github.com/BurntSushi/rtmpdump-ksv.git
+    CONFIGURE_COMMAND     ""
+    UPDATE_COMMAND        ""
+    BUILD_COMMAND         make CRYPTO=OPENSSL DESTDIR=${SYSROOT} LIBS_posix=-L${TARGET_DIR}/lib XLIBS=-ldl INC=-I${TARGET_DIR}/include CROSS_COMPILE=${TARGET}-
+    INSTALL_COMMAND       make install DESTDIR=${SYSROOT}
+    BUILD_IN_SOURCE       1
+    DEPENDS               zlib openssl iconv ncurses
 )
 
 ExternalProject_Add(
-	curl
-	GIT_REPOSITORY          https://github.com/bagder/curl.git
-	GIT_TAG                 800094802e29935e2785fb9d33c3b3a6af0ad818
-	PATCH_COMMAND           ./buildconf
-	UPDATE_COMMAND          ""
-	CONFIGURE_COMMAND 	LDFLAGS=-L${SYSROOT}/usr/local/lib LIBS=-ldl CFLAGS=-I${SYSROOT}/usr/local/include ${BASIC_CONF} --prefix=${SYSROOT}/usr/local --with-ssl --with-librtmp --disable-debug --enable-optimize --enable-warnings --disable-manual --disable-curldebug --disable-ares --enable-largefile --enable-http --enable-https --enable-file--disable-ldap --disable-ldaps --disable-rtsp --enable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smtp --disable-gophper --enable-ipv6 --enable-versioned-symbols --enable-nonblocking --enable-verbose --disable-sspi --enable-crypto-auth --enable-cookies --enable-hidden-symbols --disable-soname-bump --with-gnu-ld --without-krb4 --without-spnego --without-gssapi --with-zlib --without-egd-socket --without-polarssl --without-nss --without-ca-path --without-libssh2 --without-libidn --with-gnutls --enable-threaded-resolver
-	BUILD_COMMAND 		make
-	DEPENDS                 openssl zlib bzip2 rtmpdump libgcrypt
+    curl
+    GIT_REPOSITORY        http://github.com/bagder/curl.git
+    GIT_TAG               curl-7_41_0
+    PATCH_COMMAND         ./buildconf
+    UPDATE_COMMAND        ""
+    CONFIGURE_COMMAND     LDFLAGS=-L${SYSROOT}/usr/local/lib LIBS=-ldl CFLAGS=-I${SYSROOT}/usr/local/include ${BASIC_CONF} --prefix=${SYSROOT}/usr/local --with-ssl --with-librtmp --disable-debug --enable-optimize --enable-warnings --disable-manual --disable-curldebug --disable-ares --enable-largefile --enable-http --enable-https --enable-file--disable-ldap --disable-ldaps --disable-rtsp --enable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smtp --disable-gophper --enable-ipv6 --enable-versioned-symbols --enable-nonblocking --enable-verbose --disable-sspi --enable-crypto-auth --enable-cookies --enable-hidden-symbols --disable-soname-bump --with-gnu-ld --without-krb4 --without-spnego --without-gssapi --with-zlib --without-egd-socket --without-polarssl --without-nss --without-ca-path --without-libssh2 --without-libidn --without-gnutls --enable-threaded-resolver
+    BUILD_COMMAND         make
+    DEPENDS               openssl zlib bzip2 rtmpdump libgcrypt iconv ncurses libgcrypt
 )
 
 file(WRITE ${CMAKE_BINARY_DIR}/dbus_configure_helper.sh
@@ -537,14 +541,14 @@ ${CMAKE_BINARY_DIR}/dbus-prefix/src/dbus/configure --prefix=${TARGET_DIR} --host
 execute_process(COMMAND chmod +x ${CMAKE_BINARY_DIR}/dbus_configure_helper.sh)
 
 ExternalProject_Add(
-        dbus
-        URL               http://dbus.freedesktop.org/releases/dbus/dbus-1.9.2.tar.gz
-        URL_MD5           a568c8853eeced5a4346fa2dd8e9eda6
-        CONFIGURE_COMMAND ${CMAKE_BINARY_DIR}/dbus_configure_helper.sh
-        BUILD_COMMAND     make
-        INSTALL_COMMAND   make install
-        BUILD_IN_SOURCE   1
-        DEPENDS           expat
+    dbus
+    URL               http://dbus.freedesktop.org/releases/dbus/dbus-1.9.2.tar.gz
+    URL_MD5           a568c8853eeced5a4346fa2dd8e9eda6
+    CONFIGURE_COMMAND ${CMAKE_BINARY_DIR}/dbus_configure_helper.sh
+    BUILD_COMMAND     make
+    INSTALL_COMMAND   make install
+    BUILD_IN_SOURCE   1
+    DEPENDS           expat zlib iconv ncurses
 )
 
 ExternalProject_Add(
@@ -553,6 +557,7 @@ ExternalProject_Add(
     URL_MD5               f5898b29bbfd70502831a212d9249d10
     CONFIGURE_COMMAND     ${BASIC_CONF} --disable-debug --enable-structs --enable-raw-api --disable-purify-safety --with-gnu-ld
     BUILD_COMMAND         make
+    DEPENDS               zlib iconv ncurses
 )
 
 file(WRITE ${CMAKE_BINARY_DIR}/python_configure_helper.sh
@@ -575,27 +580,27 @@ execute_process(COMMAND chmod +x ${CMAKE_BINARY_DIR}/python_configure_helper.sh)
 
 # Note to self: diff -x generated -r -u Python-2.7.2 python | grep -v '^Only in' > /Volumes/Skivavbild/boxee-xbmc/tools/boxeebox/libs/Python-2.7.2-xcompile.patch
 ExternalProject_Add(
-	python
-	URL 				http://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.bz2
-	URL_MD5 			ba7b2f11ffdbf195ee0d111b9455a5bd
-	PATCH_COMMAND 	<SOURCE_DIR>/configure
+    python
+    URL                   http://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.bz2
+    URL_MD5               ba7b2f11ffdbf195ee0d111b9455a5bd
+    PATCH_COMMAND         <SOURCE_DIR>/configure
 		COMMAND make -j8 Parser/pgen python
 		COMMAND mv python hostpython
 		COMMAND mv Parser/pgen Parser/hostpgen
 		COMMAND make distclean
 		COMMAND patch -p1 -N < ${CMAKE_SOURCE_DIR}/Python-2.7.2-xcompile.patch
 		COMMAND patch -p1 -N < ${CMAKE_SOURCE_DIR}/Python-2.7.2-default-is-optimized.patch
-		COMMAND sed -e "13735,13738d" -i bak configure
-		COMMAND sed -e "185d" -i bak Makefile.pre.in
-		COMMAND sed -e "954,959d" -i bak Makefile.pre.in
-	CONFIGURE_COMMAND   ${CMAKE_BINARY_DIR}/python_configure_helper.sh
+		COMMAND sed -e "13735,13738d" -i.bak configure
+		COMMAND sed -e "185d" -i.bak Makefile.pre.in
+		COMMAND sed -e "954,959d" -i.bak Makefile.pre.in
+    CONFIGURE_COMMAND     ${CMAKE_BINARY_DIR}/python_configure_helper.sh
 		COMMAND rm -f Include/graminit.h
 		COMMAND rm -f Python/graminit.c
 		COMMAND Parser/hostpgen <SOURCE_DIR>/Grammar/Grammar Include/graminit.h Python/graminit.c
-	BUILD_COMMAND 		HOSTPYTHON=./hostpython HOSTPGEN=./Parser/hostpgen CROSS_COMPILE_TARGET=yes HOSTARCH=${TARGET} BUILDARCH=${HOSTMACHINE} make ${PARALLEL}
-	INSTALL_COMMAND 	HOSTPYTHON=./hostpython HOSTPGEN=./Parser/hostpgen CROSS_COMPILE_TARGET=yes HOSTARCH=${TARGET} BUILDARCH=${HOSTMACHINE} make install
-	BUILD_IN_SOURCE 	1
-	DEPENDS zlib expat bzip2 gdbm openssl sqlite libffi
+    BUILD_COMMAND         HOSTPYTHON=./hostpython HOSTPGEN=./Parser/hostpgen CROSS_COMPILE_TARGET=yes HOSTARCH=${TARGET} BUILDARCH=${HOSTMACHINE} make ${PARALLEL}
+    INSTALL_COMMAND       HOSTPYTHON=./hostpython HOSTPGEN=./Parser/hostpgen CROSS_COMPILE_TARGET=yes HOSTARCH=${TARGET} BUILDARCH=${HOSTMACHINE} make install
+    BUILD_IN_SOURCE       1
+    DEPENDS               zlib expat bzip2 gdbm openssl sqlite libffi libxml2 iconv
 )
 
 ExternalProject_Add(
@@ -604,23 +609,24 @@ ExternalProject_Add(
     URL_MD5               509dc27107c21bcd9fbf2f95f5669563
     CONFIGURE_COMMAND     ac_cv_func_setpgrp_void=no <SOURCE_DIR>/configure --prefix=${TARGET_DIR} --host=${TARGET} --enable-static --disable-shared --disable-lynx
     BUILD_COMMAND         make
+    DEPENDS               zlib iconv ncurses
 )
 
-
 ExternalProject_Add(
-	gettext
-	URL                  http://ftp.gnu.org/pub/gnu/gettext/gettext-0.19.3.tar.gz
-	URL_MD5              c365029ffc866fc4e485d9e5ca60b260
-	CONFIGURE_COMMAND    ${BASIC_CONF}
-	BUILD_COMMAND        make
-	DEPENDS iconv
+    gettext
+    URL                  http://ftp.gnu.org/pub/gnu/gettext/gettext-0.19.3.tar.gz
+    URL_MD5              c365029ffc866fc4e485d9e5ca60b260
+    PATCH_COMMAND        patch -p1 -N < ${CMAKE_SOURCE_DIR}/gettext-dont_build_docs_and_examples.patch
+    CONFIGURE_COMMAND    ${BASIC_CONF}
+    BUILD_COMMAND        make
+    DEPENDS              zlib iconv ncurses
 )
 
 file(WRITE ${CMAKE_BINARY_DIR}/glib_configure_helper.sh
 "
 export CFLAGS=\"-march=i686 -I${TARGET_DIR}/include\"
-export LIBS=\"-lpthread -lz -lffi\"
-${CMAKE_BINARY_DIR}/glib-prefix/src/glib/configure --prefix=${TARGET_DIR} --host=${TARGET} --build=${HOSTMACHINE} --target=${TARGET} CROSS_COMPILE=${TARGET}- LDFLAGS=-L${TARGET_DIR}/lib LIBFFI_CFLAGS=-I${TARGET_DIR}/lib/libffi-3.1/include LIBFFI_LIBS=-L${TARGET_DIR}/lib --enable-shared ZLIB_LIBS=${TARGET_DIR}/lib ZLIB_CFLAGS=${TARGET_DIR}/include glib_cv_uscore=yes ac_cv_func_posix_getpwuid_r=yes ac_cv_func_posix_getgrgid_r=yes glib_cv_stack_grows=no glib_cv_rtldglobal_broken=no -with-libiconv=${ICONV_TYPE} --enable-debug=no --disable-man --disable-dtrace --disable-systemtap --disable-rebuilds --enable-gtk-doc-html=no --disable-selinux --disable-fam --enable-xattr --enable-Bsymbolic --with-threads=posix --enable-gtk-doc=no
+export LIBS=\"-lpthread -lrt -ldl -lresolv -lz -liconv -lffi\"
+${CMAKE_BINARY_DIR}/glib-prefix/src/glib/configure --prefix=${TARGET_DIR} --host=${TARGET} --build=${HOSTMACHINE} --target=${TARGET} CROSS_COMPILE=${TARGET}- LDFLAGS=-L${TARGET_DIR}/lib LIBFFI_CFLAGS=-I${TARGET_DIR}/lib/libffi-3.1/include LIBFFI_LIBS=-L${TARGET_DIR}/lib --enable-shared glib_cv_uscore=yes ac_cv_func_posix_getpwuid_r=yes ac_cv_func_posix_getgrgid_r=yes glib_cv_stack_grows=no glib_cv_rtldglobal_broken=no -with-libiconv=yes --enable-debug=no --disable-man --disable-dtrace --disable-systemtap --disable-rebuilds --enable-gtk-doc-html=no --disable-selinux --disable-fam --enable-xattr --enable-Bsymbolic --with-threads=posix --enable-gtk-doc=no
 ")
 execute_process(COMMAND chmod +x ${CMAKE_BINARY_DIR}/glib_configure_helper.sh)
 
@@ -628,11 +634,12 @@ ExternalProject_Add(
     glib
     URL                   https://github.com/GNOME/glib/archive/2.40.0.tar.gz
     URL_MD5               4e453a219faf86e51f47191a1f8cb910
-    PATCH_COMMAND         NOCONFIGURE=yes ./autogen.sh
+    PATCH_COMMAND         patch -p1 -N < ${CMAKE_SOURCE_DIR}/glib-01-dont-build-tests.patch
+       COMMAND            NOCONFIGURE=yes ./autogen.sh
     CONFIGURE_COMMAND     ${CMAKE_BINARY_DIR}/glib_configure_helper.sh
     BUILD_COMMAND         make
     BUILD_IN_SOURCE       1
-    DEPENDS               libffi python pcre zlib libxml2 iconv gettext
+    DEPENDS               libffi python pcre zlib libxml2 iconv ncurses gettext
 )
 
 ExternalProject_Add(
@@ -642,12 +649,12 @@ ExternalProject_Add(
     CONFIGURE_COMMAND     ${BASIC_CONF} --without-cython
     BUILD_COMMAND         make CFLAGS=-I${TARGET_DIR}/include LDFLAGS=-L${TARGET_DIR}/lib
     INSTALL_COMMAND       make install
-    DEPENDS               libxml2 glib
+    DEPENDS               libxml2 glib zlib iconv ncurses
 )
 
 ExternalProject_Add(
     libshairplay
-    GIT_REPOSITORY        https://github.com/juhovh/shairplay.git
+    GIT_REPOSITORY        http://github.com/juhovh/shairplay.git
     PATCH_COMMAND         ./autogen.sh
         COMMAND           patch -p1 < ${CMAKE_SOURCE_DIR}/libshairplay-patches/xcode-llmvfix.patch
         COMMAND           patch -p0 < ${CMAKE_SOURCE_DIR}/libshairplay-patches/01-add_fairplay_handshake.patch
@@ -656,7 +663,7 @@ ExternalProject_Add(
       BUILD_COMMAND       make
         COMMAND           make install
     INSTALL_COMMAND       cp -P ${CMAKE_BINARY_DIR}/libshairplay-prefix/src/libshairplay/airport.key ${SYSROOT}/usr/local/lib
-        DEPENDS           libxml2 libplist
+    DEPENDS               libxml2 libplist zlib iconv ncurses
 )
 
 file(WRITE ${CMAKE_BINARY_DIR}/avahi_configure_helper.sh
@@ -677,19 +684,28 @@ ExternalProject_Add(
     CONFIGURE_COMMAND     ${CMAKE_BINARY_DIR}/avahi_configure_helper.sh
     BUILD_COMMAND         make
     BUILD_IN_SOURCE       1
-    DEPENDS               libdaemon libffi glib dbus expat
+    DEPENDS               libdaemon libffi glib dbus expat zlib iconv ncurses
 )
 
 ExternalProject_Add(
-	boost
-	URL			http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.gz/download
-	URL_MD5			93780777cfbf999a600f62883bd54b17
-	PATCH_COMMAND 		${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/boost.user-config.jam ./tools/build/v2/user-config.jam
-	CONFIGURE_COMMAND 	./bootstrap.sh --prefix=${TARGET_DIR}
-	BUILD_COMMAND 		""
-	INSTALL_COMMAND 	./b2 include=${TARGET_DIR}/include linkflags="-L${TARGET_DIR}/lib" toolset=gcc-i686 link=static target-os=linux --without-mpi --without-context --without-log --without-python --without-coroutine ${PARALLEL} install
-	BUILD_IN_SOURCE 	1
-	DEPENDS			zlib bzip2
+    libass
+    URL                   http://libass.googlecode.com/files/libass-0.10.1.tar.gz
+    URL_MD5               6cace482a013a3c4bf3b31a68ac66026
+    UPDATE_COMMAND        ""
+    CONFIGURE_COMMAND     ${BASIC_CONF} --with-gnu-ld --disable-enca --enable-fontconfig --disable-harfbuzz --disable-silent-rules --disable-test
+    DEPENDS               libpng fribidi freetype2 fontconfig zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    boost
+    URL                   http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.gz/download
+    URL_MD5               93780777cfbf999a600f62883bd54b17
+    PATCH_COMMAND         ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/boost.user-config.jam ./tools/build/v2/user-config.jam
+    CONFIGURE_COMMAND     ./bootstrap.sh --prefix=${TARGET_DIR}
+    BUILD_COMMAND         ""
+    INSTALL_COMMAND       ./b2 include=${TARGET_DIR}/include linkflags="-L${TARGET_DIR}/lib" toolset=gcc-i686 link=static target-os=linux --without-mpi --without-context --without-log --without-python --without-coroutine ${PARALLEL} install
+    BUILD_IN_SOURCE       1
+    DEPENDS               zlib bzip2 iconv ncurses
 )
 
 if(NOT EXISTS "${TARGET_DIR}/include/EGL/egl.h")
@@ -732,13 +748,46 @@ add_custom_command(OUTPUT ${TARGET_DIR}/lib/libGLESv2.so
 
 add_custom_target(dummylibs ALL DEPENDS DEPENDS ${TARGET_DIR}/lib/libEGL.so ${TARGET_DIR}/lib/libGLESv2.so)
 
+file(WRITE ${CMAKE_BINARY_DIR}/nettle_configure_helper.sh
+"
+export CFLAGS=\"-march=i686 -I${TARGET_DIR}/include\"
+export CPPFLAGS=-I${TARGET_DIR}/include
+export LDFLAGS=-L${TARGET_DIR}/lib
+${CMAKE_BINARY_DIR}/nettle-prefix/src/nettle/configure --prefix=${TARGET_DIR} --host=${TARGET} --build=${HOSTMACHINE} --target=${TARGET} CROSS_COMPILE=${TARGET}- LDFLAGS=-L${TARGET_DIR}/lib --enable-shared --disable-openssl
+")
+execute_process(COMMAND chmod +x ${CMAKE_BINARY_DIR}/nettle_configure_helper.sh)
+
 ExternalProject_Add(
-	ffmpeg
-	GIT_REPOSITORY           https://github.com/xbmc/FFmpeg.git
-	GIT_TAG                  2.4.3-Helix-beta1
-	CONFIGURE_COMMAND        <SOURCE_DIR>/configure --cross-prefix=${TARGET}- --enable-cross-compile --sysroot=${SYSROOT} --target-os=linux --arch=i686 --cpu=i686 --prefix=${TARGET_DIR} --disable-shared --enable-static --disable-programs --enable-gpl --disable-devices --disable-doc --disable-ffplay --disable-ffmpeg --disable-ffprobe --disable-ffserver --enable-runtime-cpudetect --enable-postproc --enable-pthreads --enable-muxer=spdif --enable-muxer=adts --enable-muxer=asf --enable-muxer=ipod --enable-encoder=ac3 --enable-encoder=aac --enable-encoder=wmav2 --enable-protocol=http --enable-zlib
-	UPDATE_COMMAND           ""
-	BUILD_COMMAND            make ${PARALLEL}
-	DEPENDS                  yasm
+    nettle
+    URL                   http://ftp.gnu.org/gnu/nettle/nettle-2.7.1.tar.gz
+    URL_MD5               003d5147911317931dd453520eb234a5
+    CONFIGURE_COMMAND     ${CMAKE_BINARY_DIR}/nettle_configure_helper.sh
+    BUILD_COMMAND         make
+    BUILD_IN_SOURCE       1
+    DEPENDS               openssl gmp zlib iconv ncurses
 )
 
+ExternalProject_Add(
+    gnutls
+    URL                   ftp://ftp.gnutls.org/gcrypt/gnutls/v3.3/gnutls-3.3.10.tar.xz
+    URL_MD5               c0a72b2c0553fe1c4992e30835808012
+    PATCH_COMMAND         patch -p0 < ${CMAKE_SOURCE_DIR}/size-max.patch   
+    CONFIGURE_COMMAND     <SOURCE_DIR>/configure --prefix=${TARGET_DIR} --host=${TARGET} --build=${HOSTMACHINE} --target=${TARGET} CROSS_COMPILE=${TARGET}- LDFLAGS=-L${TARGET_DIR}/lib --enable-shared --without-p11-kit --disable-nls --enable-local-libopts GMP_CFLAGS=${TARGET_DIR}/include
+    BUILD_COMMAND         make
+    BUILD_IN_SOURCE       1
+    DEPENDS               nettle zlib iconv ncurses
+)
+
+ExternalProject_Add(
+    ffmpeg
+    GIT_REPOSITORY        https://github.com/xbmc/FFmpeg.git
+    GIT_TAG               2.4.6-Helix 
+    PATCH_COMMAND         sed -i".bak" -e "s%pkg_config_default=pkg-config%export PKG_CONFIG_LIBDIR=${TARGET_DIR}/lib/pkgconfig:${SYSROOT}/usr/lib/pkgconfig%" configure
+    CONFIGURE_COMMAND     <SOURCE_DIR>/configure --prefix=${TARGET_DIR} --cross-prefix=${TARGET}- --enable-cross-compile --target-os=linux --sysroot=${SYSROOT} --extra-ldflags=-L${TARGET_DIR}/lib --extra-cflags=-L${TARGET_DIR}/include --arch=i686 --cpu=i686 --enable-shared --disable-static --sysinclude={TARGET_DIR}/include --disable-programs --enable-gpl --disable-devices --disable-doc --disable-ffplay --disable-ffmpeg --disable-ffprobe --disable-ffserver --enable-runtime-cpudetect --enable-postproc --enable-pthreads --enable-muxer=spdif --enable-muxer=adts --enable-muxer=asf --enable-muxer=mpegts --enable-muxer=ipod --enable-encoder=ac3 --enable-encoder=aac --enable-encoder=wmav2 --enable-protocol=http --disable-vaapi --disable-vdpau --enable-nonfree --disable-asm --enable-libvorbis --enable-muxer=ogg --enable-encoder=libvorbis --enable-bzlib --enable-optimizations --enable-yasm --enable-gnutls --enable-zlib --extra-libs=-lrt --extra-libs=-lpthread --extra-libs=-lgnutls --extra-libs=-lnettle --extra-libs=-lhogweed --extra-libs=-lgmp --extra-libs=-lz --extra-libs=-liconv --incdir=${TARGET}/include --libdir=${TARGET}/lib --pkg-config=pkg-config
+    UPDATE_COMMAND        ""
+    BUILD_COMMAND         make ${PARALLEL}
+    INSTALL_COMMAND       make install
+    COMMAND               ${CMAKE_COMMAND} -E copy_directory  ${CMAKE_BINARY_DIR}/ffmpeg-prefix/src/ffmpeg-build/i686-pc-linux-gnu/include ${TARGET_DIR}/include
+    COMMAND               ${CMAKE_COMMAND} -E copy_directory  ${CMAKE_BINARY_DIR}/ffmpeg-prefix/src/ffmpeg-build/i686-pc-linux-gnu/lib ${TARGET_DIR}/lib
+    DEPENDS               gnutls zlib bzip2 libvorbis nettle yasm iconv ncurses
+)

--- a/tools/boxeebox/libs/gettext-dont_build_docs_and_examples.patch
+++ b/tools/boxeebox/libs/gettext-dont_build_docs_and_examples.patch
@@ -1,0 +1,24 @@
+diff -Naur gettext-0.19.1/gettext-tools/Makefile.am gettext-0.19.1.patch/gettext-tools/Makefile.am
+--- gettext-0.19.1/gettext-tools/Makefile.am	2014-05-01 11:37:33.000000000 +0200
++++ gettext-0.19.1.patch/gettext-tools/Makefile.am	2014-06-23 16:06:15.225426222 +0200
+@@ -19,7 +19,7 @@
+ AUTOMAKE_OPTIONS = 1.5 gnu no-dependencies
+ ACLOCAL_AMFLAGS = -I m4 -I ../gettext-runtime/m4 -I ../m4 -I gnulib-m4 -I libgrep/gnulib-m4 -I libgettextpo/gnulib-m4
+ 
+-SUBDIRS = doc intl gnulib-lib libgrep src libgettextpo po projects styles misc man m4 tests gnulib-tests examples
++SUBDIRS = intl gnulib-lib libgrep src libgettextpo po projects styles misc man m4 tests gnulib-tests
+ 
+ EXTRA_DIST = misc/DISCLAIM
+ MOSTLYCLEANFILES = core *.stackdump
+diff -Naur gettext-0.19.1/gettext-tools/Makefile.in gettext-0.19.1.patch/gettext-tools/Makefile.in
+--- gettext-0.19.1/gettext-tools/Makefile.in	2014-06-10 07:42:48.000000000 +0200
++++ gettext-0.19.1.patch/gettext-tools/Makefile.in	2014-06-23 16:06:32.453461116 +0200
+@@ -1556,7 +1556,7 @@
+ top_srcdir = @top_srcdir@
+ AUTOMAKE_OPTIONS = 1.5 gnu no-dependencies
+ ACLOCAL_AMFLAGS = -I m4 -I ../gettext-runtime/m4 -I ../m4 -I gnulib-m4 -I libgrep/gnulib-m4 -I libgettextpo/gnulib-m4
+-SUBDIRS = doc intl gnulib-lib libgrep src libgettextpo po projects styles misc man m4 tests gnulib-tests examples
++SUBDIRS = intl gnulib-lib libgrep src libgettextpo po projects styles misc man m4 tests gnulib-tests
+ 
+ # Allow users to use "gnulib-tool --update".
+ 

--- a/tools/boxeebox/libs/glib-01-dont-build-tests.patch
+++ b/tools/boxeebox/libs/glib-01-dont-build-tests.patch
@@ -1,0 +1,53 @@
+From 68cbd635036fe04cd07bbb1a4829eebab2d7dc03 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Wed, 20 Aug 2014 22:46:35 +0300
+Subject: [PATCH] dont build tests
+
+---
+ Makefile.am  |    2 +-
+ configure.ac |   17 -----------------
+ 2 files changed, 1 insertions(+), 18 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 40e5cd5..db7bfc8 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -6,7 +6,7 @@ include $(top_srcdir)/glib.mk
+ 
+ ACLOCAL_AMFLAGS = -I m4macros ${ACLOCAL_FLAGS}
+ 
+-SUBDIRS = . m4macros glib gmodule gthread gobject gio po docs tests
++SUBDIRS = . m4macros glib gthread gobject po docs
+ DIST_SUBDIRS = $(SUBDIRS) build
+ 
+ bin_SCRIPTS = glib-gettextize
+diff --git a/configure.ac b/configure.ac
+index a01e58d..f310615 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2559,23 +2559,6 @@ dnl ******************************************************************
+ 
+ AM_CONDITIONAL(CROSS_COMPILING, test $cross_compiling = yes)
+ 
+-AS_IF([ test $cross_compiling = yes ], [
+-  AC_PATH_PROG(GLIB_GENMARSHAL, glib-genmarshal, no)
+-  if test x$GLIB_GENMARSHAL = xno; then
+-    AC_MSG_ERROR(Could not find a glib-genmarshal in your PATH)
+-  fi
+-
+-  AC_PATH_PROG(GLIB_COMPILE_SCHEMAS, glib-compile-schemas, no)
+-  if test x$GLIB_COMPILE_SCHEMAS = xno; then
+-    AC_MSG_ERROR(Could not find a glib-compile-schemas in your PATH)
+-  fi
+-
+-  AC_PATH_PROG(GLIB_COMPILE_RESOURCES, glib-compile-resources, no)
+-  if test x$GLIB_COMPILE_RESOURCES = xno; then
+-    AC_MSG_ERROR(Could not find a glib-compile-resources in your PATH)
+-  fi
+-])
+-
+ dnl **************************
+ dnl *** Checks for gtk-doc ***
+ dnl **************************
+-- 
+1.7.2.5

--- a/tools/boxeebox/libs/libiconv-1-fixes.patch
+++ b/tools/boxeebox/libs/libiconv-1-fixes.patch
@@ -1,0 +1,46 @@
+This file is part of MXE.
+See index.html for further information.
+
+Contains ad hoc patches for cross building.
+
+From 47345f5dcfb91da8afed7c4e6c29faa2056db447 Mon Sep 17 00:00:00 2001
+From: MXE
+Date: Fri, 7 Jun 2013 17:44:24 +1000
+Subject: [PATCH] remove gets since c++11 removed it
+ https://lists.gnu.org/archive/html/bug-gnulib/2012-03/msg00186.html
+
+
+diff --git a/srclib/stdio.in.h b/srclib/stdio.in.h
+index 473c84c..dfb59eb 100644
+--- a/srclib/stdio.in.h
++++ b/srclib/stdio.in.h
+@@ -679,22 +679,11 @@ _GL_WARN_ON_USE (getline, "getline is unportable - "
+ # endif
+ #endif
+ 
+-#if @GNULIB_GETS@
+-# if @REPLACE_STDIO_READ_FUNCS@ && @GNULIB_STDIO_H_NONBLOCKING@
+-#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
+-#   undef gets
+-#   define gets rpl_gets
+-#  endif
+-_GL_FUNCDECL_RPL (gets, char *, (char *s) _GL_ARG_NONNULL ((1)));
+-_GL_CXXALIAS_RPL (gets, char *, (char *s));
+-# else
+-_GL_CXXALIAS_SYS (gets, char *, (char *s));
+-#  undef gets
+-# endif
+-_GL_CXXALIASWARN (gets);
+ /* It is very rare that the developer ever has full control of stdin,
+-   so any use of gets warrants an unconditional warning.  Assume it is
+-   always declared, since it is required by C89.  */
++   so any use of gets warrants an unconditional warning; besides, C11
++   removed it.  */
++#undef gets
++#if HAVE_RAW_DECL_GETS
+ _GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
+ #endif
+ 
+-- 
+1.8.2.3
+

--- a/tools/boxeebox/libs/md5.patch
+++ b/tools/boxeebox/libs/md5.patch
@@ -1,0 +1,64 @@
+--- include/libssh/wrapper.h.orig	2014-12-27 12:03:55.521114159 +0100
++++ include/libssh/wrapper.h	2014-12-27 12:06:35.072310640 +0100
+@@ -52,7 +52,7 @@
+ };
+ 
+ typedef struct ssh_mac_ctx_struct *ssh_mac_ctx;
+-MD5CTX md5_init(void);
++MD5CTX ssh_md5_init(void);
+ void md5_update(MD5CTX c, const void *data, unsigned long len);
+ void md5_final(unsigned char *md,MD5CTX c);
+ 
+--- src/dh.c.orig	2014-12-27 12:08:07.441537435 +0100
++++ src/dh.c	2014-12-27 12:09:25.539205892 +0100
+@@ -906,7 +906,7 @@
+     return SSH_ERROR;
+   }
+ 
+-  ctx = md5_init();
++  ctx = ssh_md5_init();
+   if (ctx == NULL) {
+     SAFE_FREE(h);
+     return SSH_ERROR;
+@@ -1037,7 +1037,7 @@
+                 goto out;
+             }
+ 
+-            ctx = md5_init();
++            ctx = ssh_md5_init();
+             if (ctx == NULL) {
+                 free(h);
+                 rc = -1;
+--- src/kex1.c.orig	2014-12-27 12:11:18.307842585 +0100
++++ src/kex1.c	2014-12-27 12:11:38.999225682 +0100
+@@ -78,7 +78,7 @@
+     ssh_string hostn) {
+   MD5CTX md5 = NULL;
+ 
+-  md5 = md5_init();
++  md5 = ssh_md5_init();
+   if (md5 == NULL) {
+     return -1;
+   }
+--- src/libcrypto.c.orig	2014-12-27 12:12:40.977378184 +0100
++++ src/libcrypto.c	2014-12-27 12:13:14.716372667 +0100
+@@ -234,7 +234,7 @@
+   SHA512(digest, len, hash);
+ }
+ 
+-MD5CTX md5_init(void) {
++MD5CTX ssh_md5_init(void) {
+   MD5CTX c = malloc(sizeof(*c));
+   if (c == NULL) {
+     return NULL;
+--- src/libgcrypt.c.orig	2014-12-27 12:13:46.319430927 +0100
++++ src/libgcrypt.c	2014-12-27 12:13:59.611034883 +0100
+@@ -132,7 +132,7 @@
+   gcry_md_hash_buffer(GCRY_MD_SHA512, hash, digest, len);
+ }
+ 
+-MD5CTX md5_init(void) {
++MD5CTX ssh_md5_init(void) {
+   MD5CTX c = NULL;
+   gcry_md_open(&c, GCRY_MD_MD5, 0);
+ 

--- a/tools/boxeebox/libs/ncurses-gcc-5.patch
+++ b/tools/boxeebox/libs/ncurses-gcc-5.patch
@@ -1,0 +1,46 @@
+https://bugs.gentoo.org/545114
+
+extracted from the upstream change (which had many unrelated commits in one)
+
+From 97bb4678dc03e753290b39bbff30ba2825df9517 Mon Sep 17 00:00:00 2001
+From: "Thomas E. Dickey" <dickey@invisible-island.net>
+Date: Sun, 7 Dec 2014 03:10:09 +0000
+Subject: [PATCH] ncurses 5.9 - patch 20141206
+
++ modify MKlib_gen.sh to work around change in development version of
+  gcc introduced here:
+	  https://gcc.gnu.org/ml/gcc-patches/2014-06/msg02185.html
+	  https://gcc.gnu.org/ml/gcc-patches/2014-07/msg00236.html
+  (reports by Marcus Shawcroft, Maohui Lei).
+
+diff --git a/ncurses/base/MKlib_gen.sh b/ncurses/base/MKlib_gen.sh
+index d8cc3c9..b91398c 100755
+--- a/ncurses/base/MKlib_gen.sh
++++ b/ncurses/base/MKlib_gen.sh
+@@ -474,11 +474,22 @@ sed -n -f $ED1 \
+ 	-e 's/gen_$//' \
+ 	-e 's/  / /g' >>$TMP
+ 
++cat >$ED1 <<EOF
++s/  / /g
++s/^ //
++s/ $//
++s/P_NCURSES_BOOL/NCURSES_BOOL/g
++EOF
++
++# A patch discussed here:
++#	https://gcc.gnu.org/ml/gcc-patches/2014-06/msg02185.html
++# introduces spurious #line markers.  Work around that by ignoring the system's
++# attempt to define "bool" and using our own symbol here.
++sed -e 's/bool/P_NCURSES_BOOL/g' $TMP > $ED2
++cat $ED2 >$TMP
++
+ $preprocessor $TMP 2>/dev/null \
+-| sed \
+-	-e 's/  / /g' \
+-	-e 's/^ //' \
+-	-e 's/_Bool/NCURSES_BOOL/g' \
++| sed -f $ED1 \
+ | $AWK -f $AW2 \
+ | sed -f $ED3 \
+ | sed \

--- a/tools/boxeebox/libs/size-max.patch
+++ b/tools/boxeebox/libs/size-max.patch
@@ -1,0 +1,10 @@
+--- gl/read-file.c.orig	2014-11-24 10:06:35.473877332 +0100
++++ gl/read-file.c	2014-11-24 10:03:34.005876607 +0100
+@@ -27,6 +27,7 @@
+ 
+ /* Get SIZE_MAX.  */
+ #include <stdint.h>
++#include <limits.h>
+ 
+ /* Get malloc, realloc, free. */
+ #include <stdlib.h>

--- a/tools/boxeebox/toolchain/CMakeLists.txt
+++ b/tools/boxeebox/toolchain/CMakeLists.txt
@@ -30,7 +30,7 @@ ExternalProject_Add(
 	PREFIX 				${CMAKE_BINARY_DIR}/binutils
 	URL 				http://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.bz2
 	URL_MD5 			ccd264a5fa9ed992a21427c69cba91d3
-	PATCH_COMMAND 		sed -e "6128,6135d" -i bak configure # prevents binutls from failing due to newer makeinfo
+	PATCH_COMMAND 		sed -e "6128,6135d" -i.bak configure # prevents binutls from failing due to newer makeinfo
 	CONFIGURE_COMMAND	 <SOURCE_DIR>/configure --with-sysroot=${SYSROOT} --with-lib-path=${TARGET_DIR}/lib --prefix=${TARGET_DIR} --target ${TARGET} --disable-nls --disable-werror --program-prefix=${TARGET}-
 	BUILD_COMMAND		make ${PARALLEL}
 	DEPENDS 			kernel


### PR DESCRIPTION
@quarnster 
This is based on your master branch which is behind but seemed easier to add the changes to. I made sure I kept your recent changes (curl), and addressed the sed/gsed issues so it should build on linux or OSX fine.

The main issue I was having on Ubuntu 32 and 64bit was some of the libs linking to the built in libc iconv. I found I had to make sure zlib, libiconv and ncurses were build first so the libs found the external libiconv. Also had to export it in the configure line so Kodi found it too. Mysql config also exported in the configure so no more sudo'ing to be done when building.

Goal was to build the libs on OSX and Ubuntu 64 & 32bit without the iconv and gettext issues, I think I have succeeded. 
I have tested on OSX Yosemite, prerequisites as follows:

```
atk                     doxygen                 gmp                     jpeg                    m4                      sdl
autoconf                fakeroot                gmp4                    libffi                  mpc                     sdl_image
automake                flex                    gnu-sed                 libiconv                mpfr                    sdl_mixer
binutils                fontconfig              go                      libmpc                  mpfr2                   sdl_ttf
bison                   freetype                gobject-introspection   libmpc08                nspr                    swig
boost                   gawk3                   gtk+                    libmpdclient            nss                     taglib
brew-cask               gcc49                   harfbuzz                libpng                  pango                   texinfo
cairo                   gdk-pixbuf              icu4c                   libtiff                 pcre                    webp
cloog018                gettext                 intltool                libtool                 pixman                  xz
cmake                   glib                    isl011                  lzo                     pkg-config              yasm
```

Ubuntu 12.04 LTS 32bit & 15.04 LTS (but with new toolchain).

```
sudo apt-get install build-essential
sudo apt-get install texinfo
sudo apt-get install bison
sudo apt-get install flex
sudo apt-get install swig
sudo apt-get install default-jre
sudo apt-get install gperf
sudo apt-get install nasm
sudo apt-get install automake
sudo apt-get install autopoint
sudo apt-get install libtool
sudo apt-get install doxygen   
sudo apt-get install gettext
sudo apt-get install pkg-config
sudo apt-get install zip
sudo apt-get install golang
sudo apt-get install libgmp3-dev
sudo apt-get install libmpfr-dev
sudo apt-get install libmpfr-doc
sudo apt-get install mpc
sudo apt-get install libmpc-dev
sudo apt-get install libglib2.0-dev
sudo apt-get install intltool
sudo apt-get install libgtk2.0-dev
sudo apt-get install libgtk-3-dev
sudo apt-get install libperl-dev
sudo apt-get install libgtk2.0-doc
sudo apt-get install gtk-doc-tools
sudo apt-get install cmake
sudo apt-get install elfutils
sudo apt-get install libelf-dev
sudo apt-get install libssh2-1-dev
sudo apt-get install libncurses5-dev
sudo apt-get install ncurses-term
sudo apt-get install libterm-query-perl
sudo apt-get install xtermset
sudo apt-get install libmysqlclient-dev
sudo apt-get install libjasper-dev
sudo apt-get install libavahi-core-dev
sudo apt-get install libavahi-common-dev
sudo apt-get install libavahi-client-dev
sudo apt-get install samba
sudo apt-get install libboost-dev
sudo apt-get install libboost-thread-dev
sudo apt-get install libmicrohttpd-dev
sudo apt-get install python-imaging
sudo apt-get install libsdl-image1.2-dev
sudo apt-get install libsdl1.2-dev
sudo apt-get install libmysqlclient-dev
sudo apt-get install libavahi-compat-libdnssd-dev 
sudo apt-get install libltdl-dev 
sudo apt-get install avahi-daemon
sudo apt-get install liblzo2-dev
```

Updated, libssh, ffmpeg (add gnutls, make shared), taglib (static), pcre (static), downgrade libass (for now, going to retry building with the new version with yasm enabled, had problems before but should be ok now), remove enca as it isn't used at all apparently.

You can now build mysql if you want it as I have managed to get it to cross-compile, along with afpfs-ng. PVR built fine too.

I will update my github with these changes and I will do all builds on OSX Yosemite now and in the future as after testing it appears to run slightly better. A fair bit of work but worth it in the end.

Hopefully it builds OK for you...
